### PR TITLE
Adding Back Seconds for formatUptime

### DIFF
--- a/backend/pkg/restapis/server/health/helper.go
+++ b/backend/pkg/restapis/server/health/helper.go
@@ -11,13 +11,17 @@ import (
 
 // bytesToMB converts bytes to megabytes (MB)
 func bytesToMB(bytesStr string) float64 {
+	// Note: Error handling is omitted here as it would unnecessarily complicate the code
+	// for a simple conversion/reformatting operation.
 	bytes, _ := strconv.ParseFloat(bytesStr, 64)
 	return bytes / (1024 * 1024)
 }
 
-// formatUptime converts the uptime from seconds to a more readable format (days, hours, minutes)
+// formatUptime converts the uptime from seconds to a more readable format (days, hours, minutes, seconds)
 func formatUptime(uptimeSeconds string) (string, []map[string]string) {
 	// Parse the uptime seconds string to a float64
+	// Note: Error handling is omitted here as it would unnecessarily complicate the code
+	// for a simple conversion/reformatting operation.
 	seconds, _ := strconv.ParseFloat(uptimeSeconds, 64)
 
 	// Calculate the number of days
@@ -32,14 +36,18 @@ func formatUptime(uptimeSeconds string) (string, []map[string]string) {
 	minutes := int(seconds) / 60
 	seconds -= float64(minutes * 60)
 
-	// Create the formatted uptime string
-	uptimeStats := fmt.Sprintf("%d days, %d hours, %d minutes", days, hours, minutes)
+	// Calculate the remaining seconds
+	remainingSeconds := int(seconds)
 
-	// Create an array of objects with labels and values for days, hours, and minutes
+	// Create the formatted uptime string
+	uptimeStats := fmt.Sprintf("%d days, %d hours, %d minutes, %d seconds", days, hours, minutes, remainingSeconds)
+
+	// Create an array of objects with labels and values for days, hours, minutes, and seconds
 	uptime := []map[string]string{
 		{"day": strconv.Itoa(days)},
 		{"hour": strconv.Itoa(hours)},
 		{"minute": strconv.Itoa(minutes)},
+		{"second": strconv.Itoa(remainingSeconds)},
 	}
 
 	// Return the formatted uptime string and the array of uptime objects


### PR DESCRIPTION
- [+] feat(health/helper.go): add seconds to uptime formatting in formatUptime function

Note: There is no error handling for this, since it too complex adding error handling just for convert/re-format