### PR TITLE
Fix formatting for Peak Used Memory Redis health in Logger

### DIFF
--- a/backend/pkg/restapis/server/health/db.go
+++ b/backend/pkg/restapis/server/health/db.go
@@ -77,7 +77,7 @@ func DBHandler(db database.Service) fiber.Handler {
 
 		// Log the Redis health status
 		if response.RedisHealth.Status == "up" {
-			log.LogInfof("Redis Status: %s, Stats: Version: %s, Mode: %s, Connected Clients: %s, Used Memory: %s MB (%s GB), Peak Used Memory: %s (%s), Uptime: %s",
+			log.LogInfof("Redis Status: %s, Stats: Version: %s, Mode: %s, Connected Clients: %s, Used Memory: %s MB (%s GB), Peak Used Memory: %s MB (%s GB), Uptime: %s",
 				response.RedisHealth.Message, response.RedisHealth.Version, response.RedisHealth.Mode,
 				response.RedisHealth.ConnectedClients, response.RedisHealth.UsedMemory.MB, response.RedisHealth.UsedMemory.GB,
 				response.RedisHealth.PeakUsedMemory.MB, response.RedisHealth.PeakUsedMemory.GB, response.RedisHealth.UptimeStats)


### PR DESCRIPTION
- [+] fix(db.go): correct unit of measurement for Peak Used Memory in Redis log from generic to MB and GB