### PR TITLE
Docs [Internal] [Database] [Helper] Fix Typo Comment

### DIFF
--- a/backend/internal/database/helper.go
+++ b/backend/internal/database/helper.go
@@ -40,7 +40,7 @@ func parseRedisInfo(info string) map[string]string {
 
 // convertStringToInterface converts a slice of strings to a slice of interfaces.
 //
-// Note: This is pretty useful for big queries, as it can be used with single goroutines or multipe goroutines along with semaphore for MySQL queries.
+// Note: This is pretty useful for big queries, as it can be used with single goroutines or multiple goroutines along with semaphore for MySQL queries.
 // Only advanced/master Go developers know how this helper works.
 func convertStringToInterface(strs []string) []interface{} {
 	interfaces := make([]interface{}, len(strs))


### PR DESCRIPTION
- [+] fix(helper.go): correct typo in comment, 'multipe' to 'multiple'