### PR TITLE
Enhance [Internal] [Logger] Support Colorable for Windows

### DIFF
--- a/backend/internal/logger/constant.go
+++ b/backend/internal/logger/constant.go
@@ -6,13 +6,13 @@ package logger
 
 // Define ANSI color codes.
 const (
-	ColorReset     = "\033[0m"
-	ColorRed       = "\033[31m"
-	ColorGreen     = "\033[32m"
-	ColorYellow    = "\033[33m"
-	ColorBlue      = "\033[34m"
-	ColorMagenta   = "\033[35m"
-	ColorBrightRed = "\033[91m"
+	ColorReset     = "\x1b[0m"
+	ColorRed       = "\x1b[31m"
+	ColorGreen     = "\x1b[32m"
+	ColorYellow    = "\x1b[33m"
+	ColorBlue      = "\x1b[34m"
+	ColorMagenta   = "\x1b[35m"
+	ColorBrightRed = "\x1b[91m"
 )
 
 // Define log levels.

--- a/backend/internal/logger/logger.go
+++ b/backend/internal/logger/logger.go
@@ -9,10 +9,12 @@ import (
 	"io"
 	"log"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/mattn/go-colorable"
 )
 
 // Logger is a custom logger with different levels of logging.
@@ -26,6 +28,11 @@ type Logger struct {
 
 // NewLogger creates a new Logger instance with custom prefixes, colors, and time format.
 func NewLogger(out io.Writer, appName, appNameColor, timeFormat string) *Logger {
+	// Enable color output on Windows
+	if runtime.GOOS == "windows" {
+		out = colorable.NewColorableStdout()
+	}
+
 	// Set the desired time format for the loggers
 	var flags int
 	var timeFormatter func(t time.Time) string

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gofiber/fiber/v2 v2.52.4
 	github.com/gofiber/storage/redis/v3 v3.1.1
 	github.com/joho/godotenv v1.5.1
+	github.com/mattn/go-colorable v0.1.13
 	github.com/redis/go-redis/v9 v9.5.1
 )
 
@@ -22,7 +23,6 @@ require (
 	github.com/google/uuid v1.5.0 // indirect
 	github.com/klauspost/compress v1.17.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/philhofer/fwd v1.1.2 // indirect


### PR DESCRIPTION
- [+] feat(logger): add support for colored output on Windows
- [+] refactor(logger): change ANSI color codes to hexadecimal format
- [+] chore(go.mod): move go-colorable from indirect to direct dependencies

Note: This now supports across operating systems, not just Unix/Linux.