### PR TITLE
Feat [Internal] [RDB] add new constant

### DIFF
--- a/backend/internal/database/constant.go
+++ b/backend/internal/database/constant.go
@@ -43,4 +43,5 @@ const (
 	MsgRedisHighMemoryUsage      = "Redis is using a significant amount of memory"
 	MsgRedisRecentlyRestarted    = "Redis has been recently restarted"
 	MsgRedisHasStaleConnections  = "Redis has %d stale connections."
+	MsgRedisFailedToRetrieveInfo = "Failed to retrieve Redis info: %v"
 )

--- a/backend/internal/database/mysql_redis.go
+++ b/backend/internal/database/mysql_redis.go
@@ -342,7 +342,7 @@ func (s *service) checkRedisHealth(ctx context.Context, stats map[string]string)
 		// Get Redis server information
 		info, err := s.redisClient.Info(ctx).Result()
 		if err != nil {
-			stats["redis_message"] = fmt.Sprintf("Failed to retrieve Redis info: %v", err)
+			stats["redis_message"] = fmt.Sprintf(MsgRedisFailedToRetrieveInfo, err)
 		} else {
 			// Parse the Redis info response
 			redisInfo := parseRedisInfo(info)


### PR DESCRIPTION
- [+] feat(constant.go): add new constant MsgRedisFailedToRetrieveInfo
- [+] refactor(mysql_redis.go): use MsgRedisFailedToRetrieveInfo constant for redis error message

Note: Introducing this constant simplifies the localization process (e.g., translating from English to Indonesian), allowing for efficient translation through automated tools (e.g, Code Generation) or manual methods.