### PR TITLE
Enhance [Internal] [Middleware Utils] Rate Limiter

### DIFF
--- a/backend/internal/middleware/restapis_routes.go
+++ b/backend/internal/middleware/restapis_routes.go
@@ -47,7 +47,11 @@ func registerRESTAPIsRoutes(api fiber.Router, db database.Service) {
 	})
 
 	// Apply the rate limiter middleware directly to the REST API routes
-	rateLimiterRESTAPIs := NewRateLimiter(db, maxRequestRESTAPIsRateLimiter, maxExpirationRESTAPIsRateLimiter, MsgRESTAPIsVisitorGotRateLimited)
+	// Note: This method is called "higher-order function" which is better than (if-else statement which is bad)
+	rateLimiterRESTAPIs := NewRateLimiter(db,
+		WithMax(maxRequestRESTAPIsRateLimiter),
+		WithExpiration(maxExpirationRESTAPIsRateLimiter),
+		WithLimitReached(ratelimiterMsg))
 
 	// Register server APIs routes
 	serverAPIs(v1, db, rateLimiterRESTAPIs)


### PR DESCRIPTION
- [+] feat(middleware): add support for custom rate limiter options using higher-order functions
- [+] Introduce `WithMax`, `WithExpiration`, and `WithLimitReached` option functions for configuring the rate limiter middleware
- [+] Modify `NewRateLimiter` to accept variadic options and apply them to the rate limiter configuration
- [+] Implement `ratelimiterMsg` as a custom handler for the rate limiter middleware to log and send appropriate error responses

- [+] refactor(middleware): enhance `WithKeyGenerator` to support multiple middleware configurations
- [+] Use a type switch to determine the middleware configuration type and set the appropriate key generator field
- [+] Support `cache.Config` and `limiter.Config` types
- [+] Panic with an appropriate error message for unsupported config types

- [+] chore(middleware): update comments and documentation for clarity and consistency