### PR TITLE
Enhance [Internal] [Middleware Helper] Rate Limiter Message

### DIFF
--- a/backend/internal/middleware/helper.go
+++ b/backend/internal/middleware/helper.go
@@ -42,19 +42,24 @@ func hashForSignature(toHash string) string {
 }
 
 // ratelimiterMsg is a custom handler function for the rate limiter middleware.
-// It logs a message indicating that a visitor has been rate limited and sends an error response
-// with a "Too Many Requests" status code and an appropriate error message.
+// It returns a closure that logs a message indicating that a visitor has been rate limited
+// and sends an error response with a "Too Many Requests" status code and an appropriate error message.
 //
 // Parameters:
 //
-//	c: The Fiber context representing the current request.
+//	customMessage: A custom message to be logged when a visitor is rate limited.
 //
 // Returns:
 //
-//	An error indicating that the rate limit has been reached.
-func ratelimiterMsg(c *fiber.Ctx) error {
-	log.LogUserActivity(c, MsgRESTAPIsVisitorGotRateLimited)
-	return helper.SendErrorResponse(c, fiber.StatusTooManyRequests, fiber.ErrTooManyRequests.Message)
+//	A closure that takes a Fiber context and returns an error.
+//	The closure logs the custom message and sends an error response indicating that the rate limit has been reached.
+func ratelimiterMsg(customMessage string) func(*fiber.Ctx) error {
+	return func(c *fiber.Ctx) error {
+		log.LogUserActivity(c, customMessage)
+		// Note: Custom messages for the "Too Many Requests" HTTP response will not be implemented due to lazy 🤪.
+		// The default error message provided by Fiber will be used instead.
+		return helper.SendErrorResponse(c, fiber.StatusTooManyRequests, fiber.ErrTooManyRequests.Message)
+	}
 }
 
 // WithKeyGenerator is an option function for NewCacheMiddleware and NewRateLimiter that sets a custom key generator.

--- a/backend/internal/middleware/restapis_routes.go
+++ b/backend/internal/middleware/restapis_routes.go
@@ -51,7 +51,7 @@ func registerRESTAPIsRoutes(api fiber.Router, db database.Service) {
 	rateLimiterRESTAPIs := NewRateLimiter(db,
 		WithMax(maxRequestRESTAPIsRateLimiter),
 		WithExpiration(maxExpirationRESTAPIsRateLimiter),
-		WithLimitReached(ratelimiterMsg))
+		WithLimitReached(ratelimiterMsg(MsgRESTAPIsVisitorGotRateLimited)))
 
 	// Register server APIs routes
 	serverAPIs(v1, db, rateLimiterRESTAPIs)


### PR DESCRIPTION
- [+] refactor(middleware): modify ratelimiterMsg to return a closure with custom message
- [+] The ratelimiterMsg function has been refactored to return a closure that takes a Fiber context and returns an error. The closure logs a custom message indicating that a visitor has been rate limited and sends an error response with a "Too Many Requests" status code. The custom message is passed as a parameter to the ratelimiterMsg function.

- [+] feat(middleware): add support for custom messages in ratelimiterMsg
- [+] The ratelimiterMsg function now accepts a customMessage parameter, allowing custom messages to be logged when a visitor is rate limited. However, custom messages for the "Too Many Requests" HTTP response will not be implemented, and the default error message provided by Fiber will be used instead.