### PR TITLE
Implement HMAC signature for Encrypt & Decrypt data

### DIFF
--- a/backend/internal/middleware/authentication/crypto/encrypt.go
+++ b/backend/internal/middleware/authentication/crypto/encrypt.go
@@ -7,7 +7,9 @@ package crypto
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/hmac"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"errors"
 	"io"
@@ -22,18 +24,35 @@ import (
 var (
 	// secryptkey holds the secret encryption key retrieved from the environment variable "SECRETCRYPT_KEY"
 	secryptkey = os.Getenv("SECRETCRYPT_KEY")
+	// signkey holds the secret signing key retrieved from the environment variable "SIGN_KEY"
+	signkey = os.Getenv("SIGN_KEY")
 )
 
 var (
 	// ErrorInvalidCipherText is a custom error variable that represents an error
 	// which occurs when the ciphertext (encrypted text) is invalid or malformed.
 	ErrorInvalidCipherText = errors.New("invalid ciphertext")
+	// ErrorInvalidSignature is a custom error variable that represents an error
+	// which occurs when the signature is invalid or does not match the expected signature.
+	ErrorInvalidSignature = errors.New("invalid signature")
 )
+
+// signData generates an HMAC signature for the given data using the signing key.
+func signData(data []byte) []byte {
+	mac := hmac.New(sha256.New, []byte(signkey))
+	mac.Write(data)
+	return mac.Sum(nil)
+}
+
+// verifySignature verifies the HMAC signature of the given data using the signing key.
+func verifySignature(data, signature []byte) bool {
+	expectedMAC := signData(data)
+	return hmac.Equal(signature, expectedMAC)
+}
 
 // deriveKey derives an encryption key using Argon2 key derivation function or returns the secryptkey directly.
 func deriveKey(salt []byte, useArgon2 bool) []byte {
 	if useArgon2 {
-		// Note: this so expensive the cost.
 		return argon2.IDKey([]byte(secryptkey), salt, 1, 64*1024, 4, 32)
 	}
 	return []byte(secryptkey)
@@ -88,38 +107,47 @@ func decrypt(ciphertext []byte, key []byte) ([]byte, error) {
 	return plaintext, nil
 }
 
-// EncryptData encrypts the given data using AES encryption with a derived encryption key.
-// It returns the base64-encoded ciphertext, which consists of the salt and encrypted data.
+// EncryptData encrypts the given data using AES encryption with a derived encryption key and signs the ciphertext.
+// It returns the base64-encoded ciphertext and signature.
 // If useArgon2 is true, it uses Argon2 key derivation function to derive the encryption key.
-//
-// Note: This method still uses a salt even when Argon2 is set to false. The resulting ciphertext is different
-// compared to encryption without a salt.
-func EncryptData(data string, useArgon2 bool) (string, error) {
+func EncryptData(data string, useArgon2 bool) (string, string, error) {
 	salt := make([]byte, 16)
 	if _, err := rand.Read(salt); err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	key := deriveKey(salt, useArgon2)
 	ciphertext, err := encrypt([]byte(data), key)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	encryptedData := append(salt, ciphertext...)
-	return base64.StdEncoding.EncodeToString(encryptedData), nil
+	signature := signData(encryptedData)
+
+	encodedData := base64.StdEncoding.EncodeToString(encryptedData)
+	encodedSignature := base64.StdEncoding.EncodeToString(signature)
+
+	return encodedData, encodedSignature, nil
 }
 
 // DecryptData decrypts the given encrypted data using AES decryption with the same derived encryption key used during encryption.
-// It expects the encrypted data to be base64-encoded and contains the salt and ciphertext.
+// It expects the encrypted data and signature to be base64-encoded.
+// It verifies the signature before decrypting the data.
 // If useArgon2 is true, it uses Argon2 key derivation function to derive the decryption key.
-//
-// Note: This method still uses a salt even when Argon2 is set to false. The resulting ciphertext is different
-// compared to encryption without a salt.
-func DecryptData(encryptedData string, useArgon2 bool) (string, error) {
+func DecryptData(encryptedData, signature string, useArgon2 bool) (string, error) {
 	encryptedBytes, err := base64.StdEncoding.DecodeString(encryptedData)
 	if err != nil {
 		return "", err
+	}
+
+	signatureBytes, err := base64.StdEncoding.DecodeString(signature)
+	if err != nil {
+		return "", err
+	}
+
+	if !verifySignature(encryptedBytes, signatureBytes) {
+		return "", ErrorInvalidSignature
 	}
 
 	salt := encryptedBytes[:16]
@@ -137,6 +165,7 @@ func DecryptData(encryptedData string, useArgon2 bool) (string, error) {
 // processLargeData is a higher-order function that processes large data using the provided processor function.
 // It reads the data from the provided io.Reader and writes the processed data to the provided io.Writer.
 // The processor function is responsible for encrypting or decrypting the data.
+// It generates a signature for the processed data and appends it to the output.
 func processLargeData(src io.Reader, dst io.Writer, useArgon2 bool, processor func([]byte, []byte) ([]byte, error)) error {
 	salt := make([]byte, 16)
 	if _, err := rand.Read(salt); err != nil {
@@ -149,6 +178,7 @@ func processLargeData(src io.Reader, dst io.Writer, useArgon2 bool, processor fu
 		return err
 	}
 
+	hash := sha256.New()
 	buf := make([]byte, 4096)
 	for {
 		n, err := src.Read(buf)
@@ -167,6 +197,13 @@ func processLargeData(src io.Reader, dst io.Writer, useArgon2 bool, processor fu
 		if _, err := dst.Write(processed); err != nil {
 			return err
 		}
+
+		hash.Write(processed)
+	}
+
+	signature := signData(hash.Sum(nil))
+	if _, err := dst.Write(signature); err != nil {
+		return err
 	}
 
 	return nil
@@ -174,20 +211,55 @@ func processLargeData(src io.Reader, dst io.Writer, useArgon2 bool, processor fu
 
 // EncryptLargeData encrypts large data using AES encryption with a derived encryption key.
 // It reads the data from the provided io.Reader and writes the encrypted data to the provided io.Writer.
+// It generates a signature for the encrypted data and appends it to the output.
 // If useArgon2 is true, it uses Argon2 key derivation function to derive the encryption key.
-//
-// Note: This method still uses a salt even when Argon2 is set to false. The resulting ciphertext is different
-// compared to encryption without a salt.
 func EncryptLargeData(src io.Reader, dst io.Writer, useArgon2 bool) error {
 	return processLargeData(src, dst, useArgon2, encrypt)
 }
 
 // DecryptLargeData decrypts large data using AES decryption with the same derived encryption key used during encryption.
 // It reads the encrypted data from the provided io.Reader and writes the decrypted data to the provided io.Writer.
+// It verifies the signature of the encrypted data before decrypting.
 // If useArgon2 is true, it uses Argon2 key derivation function to derive the decryption key.
-//
-// Note: This method still uses a salt even when Argon2 is set to false. The resulting ciphertext is different
-// compared to encryption without a salt.
 func DecryptLargeData(src io.Reader, dst io.Writer, useArgon2 bool) error {
-	return processLargeData(src, dst, useArgon2, decrypt)
+	salt := make([]byte, 16)
+	if _, err := io.ReadFull(src, salt); err != nil {
+		return err
+	}
+
+	key := deriveKey(salt, useArgon2)
+
+	hash := sha256.New()
+	buf := make([]byte, 4096)
+	for {
+		n, err := src.Read(buf)
+		if err != nil && err != io.EOF {
+			return err
+		}
+		if n == 0 {
+			break
+		}
+
+		decrypted, err := decrypt(buf[:n], key)
+		if err != nil {
+			return err
+		}
+
+		if _, err := dst.Write(decrypted); err != nil {
+			return err
+		}
+
+		hash.Write(buf[:n])
+	}
+
+	signature := make([]byte, sha256.Size)
+	if _, err := io.ReadFull(src, signature); err != nil {
+		return err
+	}
+
+	if !verifySignature(hash.Sum(nil), signature) {
+		return ErrorInvalidSignature
+	}
+
+	return nil
 }


### PR DESCRIPTION
- [+] feat(encrypt): add HMAC signature for encrypted data

- [+] Generate HMAC signature for encrypted data using a separate signing key
- [+] Sign the ciphertext after encryption and verify the signature before decryption
- [+] Append the signature to the output when processing large data
- [+] Verify the signature of large encrypted data before decrypting
- [+] Introduce new error variable `ErrorInvalidSignature` for invalid signature cases -
- [+] refactor(encrypt): update `EncryptData` and `DecryptData` functions

- [+] `EncryptData` now returns both the base64-encoded ciphertext and signature
- [+] `DecryptData` now expects both the base64-encoded ciphertext and signature as input
- [+] Verify the signature in `DecryptData` before proceeding with decryption

- [+] docs(encrypt): update comments and remove outdated notes

- [+] Update function comments to reflect the changes in functionality
- [+] Remove outdated notes about salt usage and resulting ciphertext differences