### PR TITLE
Remove usage of ENV for cryptography techniques

### DIFF
--- a/backend/internal/middleware/authentication/crypto/chiper.go
+++ b/backend/internal/middleware/authentication/crypto/chiper.go
@@ -31,7 +31,7 @@ func decryptWithCipher(ciphertext []byte, cipher func([]byte) ([]byte, error)) (
 // It checks if the ciphertext has a valid structure and matches the expected format.
 // It expects the encrypted data and signature to be base64-encoded.
 // It returns true if the ciphertext is valid, false otherwise.
-func VerifyCiphertext(encryptedData, signature string) bool {
+func VerifyCiphertext(encryptedData, signature, signKey string) bool {
 	decodedData, err := base64.StdEncoding.DecodeString(encryptedData)
 	if err != nil {
 		return false
@@ -46,7 +46,7 @@ func VerifyCiphertext(encryptedData, signature string) bool {
 		return false
 	}
 
-	expectedSignature := signData(decodedData)
+	expectedSignature := signData(decodedData, signKey)
 
 	return subtle.ConstantTimeCompare(decodedSignature, expectedSignature) == 1
 }

--- a/backend/internal/middleware/authentication/crypto/crypto.go
+++ b/backend/internal/middleware/authentication/crypto/crypto.go
@@ -27,14 +27,18 @@ type Service interface {
 
 // cryptoService is an implementation of the crypto Service interface.
 type cryptoService struct {
-	useArgon2 bool
+	useArgon2  bool
+	secryptKey string
+	signKey    string
 }
 
 // New creates a new instance of the crypto service.
 // If useArgon2 is true, it uses Argon2 key derivation function to derive the encryption key.
-func New(useArgon2 bool) Service {
+func New(useArgon2 bool, secryptKey, signKey string) Service {
 	return &cryptoService{
-		useArgon2: useArgon2,
+		useArgon2:  useArgon2,
+		secryptKey: secryptKey,
+		signKey:    signKey,
 	}
 }
 
@@ -42,7 +46,7 @@ func New(useArgon2 bool) Service {
 // and signs the ciphertext.
 // It returns the base64-encoded ciphertext and signature.
 func (s *cryptoService) Encrypt(data string) (string, string, error) {
-	return EncryptData(data, s.useArgon2)
+	return EncryptData(data, s.useArgon2, s.secryptKey, s.signKey)
 }
 
 // Decrypt decrypts the given encrypted data using AES decryption with the same derived
@@ -50,7 +54,7 @@ func (s *cryptoService) Encrypt(data string) (string, string, error) {
 // It expects the encrypted data and signature to be base64-encoded.
 // It returns the decrypted data as a string.
 func (s *cryptoService) Decrypt(encryptedData, signature string) (string, error) {
-	return DecryptData(encryptedData, signature, s.useArgon2)
+	return DecryptData(encryptedData, signature, s.useArgon2, s.secryptKey, s.signKey)
 }
 
 // VerifyCiphertext verifies the integrity of the ciphertext without decrypting it.
@@ -58,5 +62,5 @@ func (s *cryptoService) Decrypt(encryptedData, signature string) (string, error)
 // It expects the encrypted data and signature to be base64-encoded.
 // It returns true if the ciphertext is valid, false otherwise.
 func (s *cryptoService) VerifyCiphertext(encryptedData, signature string) bool {
-	return VerifyCiphertext(encryptedData, signature)
+	return VerifyCiphertext(encryptedData, signature, s.signKey)
 }

--- a/backend/internal/middleware/authentication/crypto/crypto_test.go
+++ b/backend/internal/middleware/authentication/crypto/crypto_test.go
@@ -9,50 +9,49 @@ import (
 	"encoding/base64"
 	"h0llyw00dz-template/backend/internal/middleware/authentication/crypto"
 	"testing"
-
-	// Import the godotenv package for loading environment variables from a .env file
-	// The "_" blank identifier is used to import the package for its side effects (auto-loading .env file)
-	_ "github.com/joho/godotenv/autoload"
 )
 
 func TestVerifyCiphertext(t *testing.T) {
+	// Create an instance of the cryptoService
+	secryptKey := "gopher-testing-testing-testinggg"
+	signKey := "gopher-testing-testing-testing"
 	// Test case 1: Valid ciphertext and signature
 	plaintext := "Hello, World!"
-	encryptedData, signature, err := crypto.EncryptData(plaintext, false)
+	encryptedData, signature, err := crypto.EncryptData(plaintext, false, secryptKey, signKey)
 	if err != nil {
 		t.Fatalf("Failed to encrypt data: %v", err)
 	}
-	if !crypto.VerifyCiphertext(encryptedData, signature) {
+	if !crypto.VerifyCiphertext(encryptedData, signature, signKey) {
 		t.Error("Expected valid ciphertext, but got invalid")
 	}
 
 	// Test case 2: Invalid signature
 	invalidSignature := base64.StdEncoding.EncodeToString([]byte("invalid_signature"))
-	if crypto.VerifyCiphertext(encryptedData, invalidSignature) {
+	if crypto.VerifyCiphertext(encryptedData, invalidSignature, signKey) {
 		t.Error("Expected invalid ciphertext due to invalid signature, but got valid")
 	}
 
 	// Test case 3: Corrupted ciphertext
 	corruptedData := encryptedData[:len(encryptedData)-5] + "12345"
-	if crypto.VerifyCiphertext(corruptedData, signature) {
+	if crypto.VerifyCiphertext(corruptedData, signature, signKey) {
 		t.Error("Expected invalid ciphertext due to corruption, but got valid")
 	}
 
 	// Test case 4: Ciphertext too short
 	shortData := encryptedData[:10]
-	if crypto.VerifyCiphertext(shortData, signature) {
+	if crypto.VerifyCiphertext(shortData, signature, signKey) {
 		t.Error("Expected invalid ciphertext due to short length, but got valid")
 	}
 
 	// Test case 5: Invalid nonce length
 	invalidNonceData := encryptedData[:5] + encryptedData[10:]
-	if crypto.VerifyCiphertext(invalidNonceData, signature) {
+	if crypto.VerifyCiphertext(invalidNonceData, signature, signKey) {
 		t.Error("Expected invalid ciphertext due to invalid nonce length, but got valid")
 	}
 
 	// Test case 6: Invalid ciphertext length
 	invalidCiphertextData := encryptedData[:len(encryptedData)-3]
-	if crypto.VerifyCiphertext(invalidCiphertextData, signature) {
+	if crypto.VerifyCiphertext(invalidCiphertextData, signature, signKey) {
 		t.Error("Expected invalid ciphertext due to invalid ciphertext length, but got valid")
 	}
 
@@ -63,19 +62,22 @@ func TestVerifyCiphertext(t *testing.T) {
 		t.Fatalf("Failed to generate random data: %v", err)
 	}
 	randomEncryptedData := base64.StdEncoding.EncodeToString(randomData)
-	if crypto.VerifyCiphertext(randomEncryptedData, signature) {
+	if crypto.VerifyCiphertext(randomEncryptedData, signature, signKey) {
 		t.Error("Expected invalid ciphertext for random data, but got valid")
 	}
 }
 
 func TestEncryptDecrypt(t *testing.T) {
+	// Create an instance of the cryptoService
+	secryptKey := "gopher-testing-testing-testinggg"
+	signKey := "gopher-testing-testing-testing"
 	// Test case 1: Encrypt and decrypt data using Argon2
 	plaintext := "Hello, World!"
-	encryptedData, signature, err := crypto.EncryptData(plaintext, true)
+	encryptedData, signature, err := crypto.EncryptData(plaintext, true, secryptKey, signKey)
 	if err != nil {
 		t.Fatalf("Failed to encrypt data: %v", err)
 	}
-	decryptedText, err := crypto.DecryptData(encryptedData, signature, true)
+	decryptedText, err := crypto.DecryptData(encryptedData, signature, true, secryptKey, signKey)
 	if err != nil {
 		t.Fatalf("Failed to decrypt data: %v", err)
 	}
@@ -84,11 +86,11 @@ func TestEncryptDecrypt(t *testing.T) {
 	}
 
 	// Test case 2: Encrypt and decrypt data without Argon2
-	encryptedData, signature, err = crypto.EncryptData(plaintext, false)
+	encryptedData, signature, err = crypto.EncryptData(plaintext, false, secryptKey, signKey)
 	if err != nil {
 		t.Fatalf("Failed to encrypt data: %v", err)
 	}
-	decryptedText, err = crypto.DecryptData(encryptedData, signature, false)
+	decryptedText, err = crypto.DecryptData(encryptedData, signature, false, secryptKey, signKey)
 	if err != nil {
 		t.Fatalf("Failed to decrypt data: %v", err)
 	}
@@ -98,15 +100,54 @@ func TestEncryptDecrypt(t *testing.T) {
 
 	// Test case 3: Decrypt with invalid signature
 	invalidSignature := base64.StdEncoding.EncodeToString([]byte("invalid_signature"))
-	_, err = crypto.DecryptData(encryptedData, invalidSignature, false)
+	_, err = crypto.DecryptData(encryptedData, invalidSignature, false, secryptKey, signKey)
 	if err != crypto.ErrorInvalidSignature {
 		t.Errorf("Expected ErrorInvalidSignature, but got: %v", err)
 	}
 
 	// Test case 4: Decrypt with corrupted ciphertext
 	corruptedData := encryptedData[:len(encryptedData)-5] + "12345"
-	_, err = crypto.DecryptData(corruptedData, signature, false)
+	_, err = crypto.DecryptData(corruptedData, signature, false, secryptKey, signKey)
 	if err == nil {
 		t.Error("Expected decryption error, but got nil")
+	}
+}
+
+func TestCryptoService(t *testing.T) {
+	// Create an instance of the cryptoService
+	useArgon2 := false
+	secryptKey := "gopher-testing-testing-testinggg"
+	signKey := "gopher-testing-testing-testing"
+	service := crypto.New(useArgon2, secryptKey, signKey)
+
+	// Test case 1: Encrypt and decrypt data
+	plaintext := "Hello, World!"
+	encryptedData, signature, err := service.Encrypt(plaintext)
+	if err != nil {
+		t.Fatalf("Failed to encrypt data: %v", err)
+	}
+	decryptedText, err := service.Decrypt(encryptedData, signature)
+	if err != nil {
+		t.Fatalf("Failed to decrypt data: %v", err)
+	}
+	if decryptedText != plaintext {
+		t.Errorf("Decrypted text does not match the original plaintext")
+	}
+
+	// Test case 2: Verify valid ciphertext
+	if !service.VerifyCiphertext(encryptedData, signature) {
+		t.Error("Expected valid ciphertext, but got invalid")
+	}
+
+	// Test case 3: Verify invalid signature
+	invalidSignature := "invalid-signature"
+	if service.VerifyCiphertext(encryptedData, invalidSignature) {
+		t.Error("Expected invalid ciphertext due to invalid signature, but got valid")
+	}
+
+	// Test case 4: Verify corrupted ciphertext
+	corruptedData := encryptedData[:len(encryptedData)-5] + "12345"
+	if service.VerifyCiphertext(corruptedData, signature) {
+		t.Error("Expected invalid ciphertext due to corruption, but got valid")
 	}
 }

--- a/backend/internal/middleware/authentication/crypto/decrypt.go
+++ b/backend/internal/middleware/authentication/crypto/decrypt.go
@@ -88,7 +88,7 @@ func decrypt(ciphertext []byte, key []byte) ([]byte, error) {
 // It expects the encrypted data and signature to be base64-encoded.
 // It verifies the signature before decrypting the data.
 // If useArgon2 is true, it uses Argon2 key derivation function to derive the decryption key.
-func DecryptData(encryptedData, signature string, useArgon2 bool) (string, error) {
+func DecryptData(encryptedData, signature string, useArgon2 bool, secryptKey, signKey string) (string, error) {
 	encryptedBytes, err := base64.StdEncoding.DecodeString(encryptedData)
 	if err != nil {
 		return "", err
@@ -99,14 +99,14 @@ func DecryptData(encryptedData, signature string, useArgon2 bool) (string, error
 		return "", err
 	}
 
-	if !verifySignature(encryptedBytes, signatureBytes) {
+	if !verifySignature(encryptedBytes, signatureBytes, signKey) {
 		return "", ErrorInvalidSignature
 	}
 
 	salt := encryptedBytes[:16]
 	ciphertext := encryptedBytes[16:]
 
-	key := deriveKey(salt, useArgon2)
+	key := deriveKey(salt, useArgon2, secryptKey)
 	plaintext, err := decrypt(ciphertext, key)
 	if err != nil {
 		return "", err

--- a/backend/internal/middleware/authentication/crypto/decrypt_large.go
+++ b/backend/internal/middleware/authentication/crypto/decrypt_large.go
@@ -15,13 +15,13 @@ import (
 // If useArgon2 is true, it uses Argon2 key derivation function to derive the decryption key.
 //
 // TODO: Improve this.
-func DecryptLargeData(src io.Reader, dst io.Writer, useArgon2 bool) error {
+func DecryptLargeData(src io.Reader, dst io.Writer, useArgon2 bool, secryptKey, signKey string) error {
 	salt := make([]byte, 16)
 	if _, err := io.ReadFull(src, salt); err != nil {
 		return err
 	}
 
-	key := deriveKey(salt, useArgon2)
+	key := deriveKey(salt, useArgon2, secryptKey)
 
 	hash := sha256.New()
 	buf := make([]byte, 4096)
@@ -51,7 +51,7 @@ func DecryptLargeData(src io.Reader, dst io.Writer, useArgon2 bool) error {
 		return err
 	}
 
-	if !verifySignature(hash.Sum(nil), signature) {
+	if !verifySignature(hash.Sum(nil), signature, signKey) {
 		return ErrorInvalidSignature
 	}
 

--- a/backend/internal/middleware/authentication/crypto/encrypt.go
+++ b/backend/internal/middleware/authentication/crypto/encrypt.go
@@ -77,20 +77,20 @@ func encrypt(data []byte, key []byte) ([]byte, error) {
 // EncryptData encrypts the given data using AES encryption with a derived encryption key and signs the ciphertext.
 // It returns the base64-encoded ciphertext and signature.
 // If useArgon2 is true, it uses Argon2 key derivation function to derive the encryption key.
-func EncryptData(data string, useArgon2 bool) (string, string, error) {
+func EncryptData(data string, useArgon2 bool, secryptKey, signKey string) (string, string, error) {
 	salt := make([]byte, 16)
 	if _, err := rand.Read(salt); err != nil {
 		return "", "", err
 	}
 
-	key := deriveKey(salt, useArgon2)
+	key := deriveKey(salt, useArgon2, secryptKey)
 	ciphertext, err := encrypt([]byte(data), key)
 	if err != nil {
 		return "", "", err
 	}
 
 	encryptedData := append(salt, ciphertext...)
-	signature := signData(encryptedData)
+	signature := signData(encryptedData, signKey)
 
 	encodedData := base64.StdEncoding.EncodeToString(encryptedData)
 	encodedSignature := base64.StdEncoding.EncodeToString(signature)

--- a/backend/internal/middleware/authentication/crypto/encrypt_large.go
+++ b/backend/internal/middleware/authentication/crypto/encrypt_large.go
@@ -12,6 +12,6 @@ import "io"
 // If useArgon2 is true, it uses Argon2 key derivation function to derive the encryption key.
 //
 // TODO: Improve this.
-func EncryptLargeData(src io.Reader, dst io.Writer, useArgon2 bool) error {
-	return processLargeData(src, dst, useArgon2, encrypt)
+func EncryptLargeData(src io.Reader, dst io.Writer, useArgon2 bool, secryptKey, signKey string) error {
+	return processLargeData(src, dst, useArgon2, secryptKey, signKey, encrypt)
 }

--- a/backend/internal/middleware/authentication/crypto/helper.go
+++ b/backend/internal/middleware/authentication/crypto/helper.go
@@ -11,28 +11,8 @@ import (
 	"crypto/subtle"
 	"errors"
 	"io"
-	"os"
 
-	// Import the godotenv package for loading environment variables from a .env file
-	// The "_" blank identifier is used to import the package for its side effects (auto-loading .env file)
-	_ "github.com/joho/godotenv/autoload"
 	"golang.org/x/crypto/argon2"
-)
-
-var (
-	// secryptkey holds the secret encryption key.
-	//
-	// NOTE: In production, this key should be kept secret and not stored in an environment variable.
-	// The reason it is set from an environment variable here is for ease of testing.
-	// Retrieve the secret encryption key from the environment variable "SECRETCRYPT_KEY".
-	secryptkey = os.Getenv("SECRETCRYPT_KEY")
-
-	// signkey holds the secret signing key.
-	//
-	// NOTE: In production, this key should be kept secret and not stored in an environment variable.
-	// The reason it is set from an environment variable here is for ease of testing.
-	// Retrieve the secret signing key from the environment variable "SIGN_KEY".
-	signkey = os.Getenv("SIGN_KEY")
 )
 
 var (
@@ -45,39 +25,39 @@ var (
 )
 
 // signData generates an HMAC signature for the given data using the signing key.
-func signData(data []byte) []byte {
-	mac := hmac.New(sha256.New, []byte(signkey))
+func signData(data []byte, signKey string) []byte {
+	mac := hmac.New(sha256.New, []byte(signKey))
 	mac.Write(data)
 	return mac.Sum(nil)
 }
 
 // verifySignature verifies the HMAC signature of the given data using the signing key.
-func verifySignature(data, signature []byte) bool {
-	expectedMAC := signData(data)
+func verifySignature(data, signature []byte, signKey string) bool {
+	expectedMAC := signData(data, signKey)
 	return subtle.ConstantTimeCompare(signature, expectedMAC) == 1
 }
 
 // deriveKey derives an encryption key using Argon2 key derivation function or returns the secryptkey directly.
-func deriveKey(salt []byte, useArgon2 bool) []byte {
+func deriveKey(salt []byte, useArgon2 bool, secryptKey string) []byte {
 	// Note: Using Argon2 is expensive (100MB+ per encrypt/decrypt) the cost, which is not recommended.
 	// I might try to introduce cryptographic techniques to implement a similar but cheaper approach and a new cipher from scratch later.
 	if useArgon2 {
-		return argon2.IDKey([]byte(secryptkey), salt, 1, 64*1024, 4, 32)
+		return argon2.IDKey([]byte(secryptKey), salt, 1, 64*1024, 4, 32)
 	}
-	return []byte(secryptkey)
+	return []byte(secryptKey)
 }
 
 // processLargeData is a higher-order function that processes large data using the provided processor function.
 // It reads the data from the provided io.Reader and writes the processed data to the provided io.Writer.
 // The processor function is responsible for encrypting or decrypting the data.
 // It generates a signature for the processed data and appends it to the output.
-func processLargeData(src io.Reader, dst io.Writer, useArgon2 bool, processor func([]byte, []byte) ([]byte, error)) error {
+func processLargeData(src io.Reader, dst io.Writer, useArgon2 bool, secryptKey, signKey string, processor func([]byte, []byte) ([]byte, error)) error {
 	salt := make([]byte, 16)
 	if _, err := rand.Read(salt); err != nil {
 		return err
 	}
 
-	key := deriveKey(salt, useArgon2)
+	key := deriveKey(salt, useArgon2, secryptKey)
 
 	if _, err := dst.Write(salt); err != nil {
 		return err
@@ -106,7 +86,7 @@ func processLargeData(src io.Reader, dst io.Writer, useArgon2 bool, processor fu
 		hash.Write(processed)
 	}
 
-	signature := signData(hash.Sum(nil))
+	signature := signData(hash.Sum(nil), signKey)
 	if _, err := dst.Write(signature); err != nil {
 		return err
 	}


### PR DESCRIPTION
- [+] fix(crypto): add secryptKey and signKey parameters to VerifyCiphertext function
- [+] feat(crypto): add secryptKey and signKey fields to cryptoService struct
- [+] feat(crypto): pass secryptKey and signKey to EncryptData and DecryptData functions
- [+] test(crypto): update tests to include secryptKey and signKey parameters
- [+] refactor(crypto): remove usage of environment variables for secryptKey and signKey
- [+] feat(crypto): add secryptKey and signKey parameters to DecryptLargeData function
- [+] feat(crypto): pass signKey to verifySignature function in DecryptLargeData
- [+] feat(crypto): add secryptKey and signKey parameters to EncryptLargeData function
- [+] feat(crypto): pass secryptKey and signKey to processLargeData function
- [+] refactor(crypto): remove unused imports and comments related to environment variables