### PR TITLE
Docs [Internal] [Middleware] REST APIs Root Group Redirect

### DIFF
--- a/backend/internal/middleware/restapis_routes.go
+++ b/backend/internal/middleware/restapis_routes.go
@@ -62,6 +62,10 @@ func registerRESTAPIsRoutes(api fiber.Router, db database.Service) {
 		Routes: []APIRoute{},
 	}
 
+	// Note: This method is also called a "higher-order function",
+	// similar to another configuration where "...interface{}" is used.
+	// This is one of the reasons why I like Go. For example, when I'm lazy to implement something from scratch,
+	// I can just use a package that is already stable then build on top of it using higher-order functions.
 	redirectMiddleware := NewRedirectMiddleware(
 		WithRedirectRules(map[string]string{
 			"v1": "/",


### PR DESCRIPTION
- [+] refactor(middleware): add explanatory comment for higher-order function usage in registerRESTAPIsRoutes