### PR TITLE
Implement [Internal] [Cryptography] Hybrid Encrypt Cookie

### DIFF
--- a/backend/internal/middleware/authentication/crypto/hybrid/decryptcookie.go
+++ b/backend/internal/middleware/authentication/crypto/hybrid/decryptcookie.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// License: BSD 3-Clause License
+
+package hybrid
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+
+	"golang.org/x/crypto/chacha20poly1305"
+)
+
+// DecryptCookie decrypts a cookie value using a hybrid decryption scheme.
+func DecryptCookie(encodedCookie, key string) (string, error) {
+	keyDecoded, err := base64.StdEncoding.DecodeString(key)
+	if err != nil {
+		return "", ErrorInvalidKey
+	}
+
+	decodedCookie, err := base64.StdEncoding.DecodeString(encodedCookie)
+	if err != nil {
+		return "", ErrorInvalidCookie
+	}
+
+	decryptFn := func(encryptedCookie []byte) ([]byte, error) {
+		// Extract the nonces and encrypted cookie value
+		if len(encryptedCookie) < 12+chacha20poly1305.NonceSize {
+			return nil, ErrorInvalidCookie
+		}
+		aesNonce := encryptedCookie[:12]
+		chachaNonce := encryptedCookie[12 : 12+chacha20poly1305.NonceSize]
+		ciphertext := encryptedCookie[12+chacha20poly1305.NonceSize:]
+
+		// Decrypt the cookie value using ChaCha20-Poly1305
+		aesCiphertext, err := decryptChaCha20Poly1305(ciphertext, chachaNonce, keyDecoded)
+		if err != nil {
+			return nil, err
+		}
+
+		// Decrypt the AES-GCM ciphertext
+		plaintext, err := decryptAESGCM(aesCiphertext, aesNonce, keyDecoded)
+		if err != nil {
+			return nil, err
+		}
+
+		return plaintext, nil
+	}
+
+	plaintext, err := decryptFn(decodedCookie)
+	if err != nil {
+		return "", err
+	}
+
+	return string(plaintext), nil
+}
+
+// decryptAESGCM decrypts the ciphertext using AES-GCM and returns the plaintext.
+func decryptAESGCM(ciphertext, nonce, key []byte) ([]byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	plaintext, err := aesgcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return plaintext, nil
+}
+
+// decryptChaCha20Poly1305 decrypts the ciphertext using ChaCha20-Poly1305 and returns the plaintext.
+func decryptChaCha20Poly1305(ciphertext, nonce, key []byte) ([]byte, error) {
+	aead, err := chacha20poly1305.New(key)
+	if err != nil {
+		return nil, err
+	}
+
+	plaintext, err := aead.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return plaintext, nil
+}

--- a/backend/internal/middleware/authentication/crypto/hybrid/encryptcookie.go
+++ b/backend/internal/middleware/authentication/crypto/hybrid/encryptcookie.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// License: BSD 3-Clause License
+
+package hybrid
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"io"
+
+	"golang.org/x/crypto/chacha20poly1305"
+)
+
+// EncryptCookie encrypts a cookie value using a hybrid encryption scheme.
+func EncryptCookie(value, key string) (string, error) {
+	keyDecoded, err := base64.StdEncoding.DecodeString(key)
+	if err != nil {
+		return "", ErrorInvalidKey
+	}
+
+	encryptFn := func(plaintext []byte) ([]byte, error) {
+		// Encrypt the plaintext using AES-GCM
+		ciphertext, aesNonce, err := encryptAESGCM(plaintext, keyDecoded)
+		if err != nil {
+			return nil, err
+		}
+
+		// Encrypt the AES-GCM ciphertext using ChaCha20-Poly1305
+		encryptedCookie, chachaNonce, err := encryptChaCha20Poly1305(ciphertext, keyDecoded)
+		if err != nil {
+			return nil, err
+		}
+
+		// Combine the nonces and encrypted cookie value
+		noncesAndCiphertext := append(aesNonce, chachaNonce...)
+		noncesAndCiphertext = append(noncesAndCiphertext, encryptedCookie...)
+		return noncesAndCiphertext, nil
+	}
+
+	encryptedCookie, err := encryptFn([]byte(value))
+	if err != nil {
+		return "", err
+	}
+
+	encodedCookie := base64.StdEncoding.EncodeToString(encryptedCookie)
+	return encodedCookie, nil
+}
+
+// encryptAESGCM encrypts the plaintext using AES-GCM and returns the ciphertext and nonce.
+func encryptAESGCM(plaintext, key []byte) ([]byte, []byte, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, nil, err
+	}
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	nonce := make([]byte, aesgcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, nil, err
+	}
+
+	ciphertext := aesgcm.Seal(nil, nonce, plaintext, nil)
+	return ciphertext, nonce, nil
+}
+
+// encryptChaCha20Poly1305 encrypts the plaintext using ChaCha20-Poly1305 and returns the ciphertext and nonce.
+func encryptChaCha20Poly1305(plaintext, key []byte) ([]byte, []byte, error) {
+	aead, err := chacha20poly1305.New(key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	nonce := make([]byte, aead.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, nil, err
+	}
+
+	ciphertext := aead.Seal(nil, nonce, plaintext, nil)
+	return ciphertext, nonce, nil
+}

--- a/backend/internal/middleware/authentication/crypto/hybrid/hybird.go
+++ b/backend/internal/middleware/authentication/crypto/hybrid/hybird.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// License: BSD 3-Clause License
+
+package hybrid
+
+import "errors"
+
+var (
+	// ErrorInvalidCookie is a custom error variable that represents an error
+	// which occurs when the cookie format is invalid or malformed.
+	ErrorInvalidCookie = errors.New("invalid cookie format")
+	// ErrorInvalidKey is a custom error variable that represents an error
+	// which occurs when the provided key is invalid or cannot be decoded.
+	ErrorInvalidKey = errors.New("invalid key")
+)
+
+// Service is the interface for the hybrid encryption service.
+// It provides methods for cookie encryption and decryption using a hybrid encryption scheme.
+type Service interface {
+	// EncryptCookie encrypts a cookie value using a hybrid encryption scheme.
+	// It takes the cookie value as input and returns the base64-encoded encrypted cookie.
+	EncryptCookie(value string) (string, error)
+
+	// DecryptCookie decrypts a cookie value using a hybrid decryption scheme.
+	// It takes the base64-encoded encrypted cookie as input and returns the decrypted cookie value.
+	DecryptCookie(encodedCookie string) (string, error)
+}
+
+// cryptoService is an implementation of the hybrid encryption Service interface.
+type cryptoService struct {
+	key string
+}
+
+// New creates a new instance of the hybrid encryption service.
+// It takes the encryption key as input.
+func New(key string) Service {
+	return &cryptoService{
+		key: key,
+	}
+}
+
+// EncryptCookie encrypts a cookie value using a hybrid encryption scheme.
+// It takes the cookie value as input and returns the base64-encoded encrypted cookie.
+func (s *cryptoService) EncryptCookie(value string) (string, error) {
+	return EncryptCookie(value, s.key)
+}
+
+// DecryptCookie decrypts a cookie value using a hybrid decryption scheme.
+// It takes the base64-encoded encrypted cookie as input and returns the decrypted cookie value.
+func (s *cryptoService) DecryptCookie(encodedCookie string) (string, error) {
+	return DecryptCookie(encodedCookie, s.key)
+}

--- a/backend/internal/middleware/authentication/crypto/hybrid/hybrid_test.go
+++ b/backend/internal/middleware/authentication/crypto/hybrid/hybrid_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// License: BSD 3-Clause License
+
+package hybrid_test
+
+import (
+	"h0llyw00dz-template/backend/internal/middleware/authentication/crypto/hybrid"
+	"testing"
+
+	"github.com/gofiber/fiber/v2/middleware/encryptcookie"
+)
+
+func TestEncryptDecryptCookie(t *testing.T) {
+	// Generate a random encryption key
+	key := encryptcookie.GenerateKey()
+
+	// Create an instance of the hybrid encryption service
+	service := hybrid.New(key)
+
+	// Test cases
+	testCases := []struct {
+		name  string
+		value string
+	}{
+		{
+			name:  "Simple cookie value",
+			value: "hello world",
+		},
+		{
+			name:  "Complex cookie value",
+			value: "!@#$%^&*()_+=-`~[]{}|;':\"<>,.?/\\",
+		},
+		{
+			name:  "Empty cookie value",
+			value: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Encrypt the cookie value
+			encryptedCookie, err := service.EncryptCookie(tc.value)
+			if err != nil {
+				t.Fatalf("Failed to encrypt cookie: %v", err)
+			}
+
+			// Decrypt the encrypted cookie value
+			decryptedValue, err := service.DecryptCookie(encryptedCookie)
+			if err != nil {
+				t.Fatalf("Failed to decrypt cookie: %v", err)
+			}
+
+			// Compare the decrypted value with the original value
+			if decryptedValue != tc.value {
+				t.Errorf("Decrypted value does not match the original value")
+				t.Errorf("Expected: %s", tc.value)
+				t.Errorf("Got: %s", decryptedValue)
+			}
+		})
+	}
+
+	t.Run("Invalid cookie format", func(t *testing.T) {
+		// Create an invalid cookie format
+		invalidCookie := "invalid-cookie-format"
+
+		// Try to decrypt the invalid cookie
+		_, err := service.DecryptCookie(invalidCookie)
+		if err != hybrid.ErrorInvalidCookie {
+			t.Errorf("Expected error: %v", hybrid.ErrorInvalidCookie)
+			t.Errorf("Got: %v", err)
+		}
+	})
+
+	t.Run("Invalid base64-encoded key", func(t *testing.T) {
+		// Create an invalid base64-encoded key
+		invalidKey := "invalid-key"
+
+		// Create an instance of the hybrid encryption service with the invalid key
+		invalidService := hybrid.New(invalidKey)
+
+		// Try to encrypt a cookie value with the invalid key
+		_, err := invalidService.EncryptCookie("test")
+		if err == nil {
+			t.Error("Expected an error, got nil")
+		}
+
+		// Try to decrypt a cookie value with the invalid key
+		_, err = invalidService.DecryptCookie("test")
+		if err == nil {
+			t.Error("Expected an error, got nil")
+		}
+	})
+}


### PR DESCRIPTION
- [+] feat(hybrid): implement hybrid encryption for secure cookie storage
- [+] Add the following:
- [+] hybrid package for hybrid encryption of cookies
- [+] EncryptCookie function to encrypt cookies using AES-GCM and ChaCha20-Poly1305
- [+] DecryptCookie function to decrypt cookies using AES-GCM and ChaCha20-Poly1305
- [+] Service interface for the hybrid encryption service
- [+] cryptoService struct implementing the Service interface
- [+] New function to create a new instance of the hybrid encryption service
- [+] Unit tests for the hybrid encryption functionality

Note: This should work and integrate with the "Fiber EncryptCookie" functionality.