### PR TITLE
Refactor [Internal] [Middleware Utils] Redirect

### DIFF
--- a/backend/internal/middleware/helper.go
+++ b/backend/internal/middleware/helper.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gofiber/fiber/v2/middleware/encryptcookie"
 	"github.com/gofiber/fiber/v2/middleware/keyauth"
 	"github.com/gofiber/fiber/v2/middleware/limiter"
+	"github.com/gofiber/fiber/v2/middleware/redirect"
 	"github.com/gofiber/fiber/v2/middleware/session"
 	"github.com/google/uuid"
 )
@@ -278,26 +279,24 @@ func WithAllowOriginsFunc(allowOriginsFunc func(string) bool) CORSOption {
 	}
 }
 
-// RedirectConfig represents the configuration options for the redirect middleware.
-type RedirectConfig struct {
-	Rules      map[string]string
-	StatusCode int
-}
-
-// RedirectOption is a function that configures the redirect middleware.
-type RedirectOption func(*RedirectConfig)
-
 // WithRedirectRules sets the redirect rules for the redirect middleware.
-func WithRedirectRules(rules map[string]string) RedirectOption {
-	return func(config *RedirectConfig) {
+func WithRedirectRules(rules map[string]string) func(*redirect.Config) {
+	return func(config *redirect.Config) {
 		config.Rules = rules
 	}
 }
 
 // WithRedirectStatusCode sets the HTTP status code for the redirect response.
-func WithRedirectStatusCode(statusCode int) RedirectOption {
-	return func(config *RedirectConfig) {
+func WithRedirectStatusCode(statusCode int) func(*redirect.Config) {
+	return func(config *redirect.Config) {
 		config.StatusCode = statusCode
+	}
+}
+
+// WithRedirectNext sets the function to determine whether to skip the redirect for a given request.
+func WithRedirectNext(next func(*fiber.Ctx) bool) func(*redirect.Config) {
+	return func(config *redirect.Config) {
+		config.Next = next
 	}
 }
 

--- a/backend/internal/middleware/utils.go
+++ b/backend/internal/middleware/utils.go
@@ -368,23 +368,17 @@ func NewEncryptedCookieMiddleware(options ...interface{}) fiber.Handler {
 //	  }),
 //	  WithRedirectStatusCode(fiber.StatusMovedPermanently),
 //	)
-func NewRedirectMiddleware(options ...RedirectOption) fiber.Handler {
-	// Create a new redirect middleware configuration with default values
-	config := RedirectConfig{
-		Rules:      make(map[string]string),
-		StatusCode: fiber.StatusMovedPermanently,
-	}
+func NewRedirectMiddleware(options ...func(*redirect.Config)) fiber.Handler {
+	// Create a new redirect configuration with default values
+	config := redirect.Config{}
 
-	// Apply any additional options to the redirect configuration
+	// Apply the provided options to the redirect configuration
 	for _, option := range options {
 		option(&config)
 	}
 
 	// Create the redirect middleware with the configured options
-	return redirect.New(redirect.Config{
-		Rules:      config.Rules,
-		StatusCode: config.StatusCode,
-	})
+	return redirect.New(config)
 }
 
 // NewSessionMiddleware creates a new session middleware with optional custom configuration options.


### PR DESCRIPTION
- [+] refactor(middleware): use fiber's redirect middleware instead of custom implementation
- [+] Remove custom `RedirectConfig` and `RedirectOption` types
- [+] Update `WithRedirectRules` and `WithRedirectStatusCode` to use `redirect.Config` from fiber
- [+] Add `WithRedirectNext` option to set the `Next` function in `redirect.Config`
- [+] Simplify `NewRedirectMiddleware` to use `redirect.Config` directly instead of custom config