### PR TITLE
Refactor [Internal] [Middleware] [Route Config] ErrorHandler

### DIFF
--- a/backend/pkg/restapis/helper/restapis_error.go
+++ b/backend/pkg/restapis/helper/restapis_error.go
@@ -26,7 +26,7 @@ func ErrorHandler(c *fiber.Ctx) error {
 	// If a crash/panics occurs, return a generic error response
 	if err != nil {
 		// Note: This error is used to handle crash/panics because other errors are already handled independently.
-		return fiber.NewError(fiber.StatusInternalServerError)
+		return SendErrorResponse(c, fiber.StatusInternalServerError, fiber.ErrInternalServerError.Message)
 	}
 
 	// No errors, continue with the next middleware


### PR DESCRIPTION
- [+] refactor(restapis_error.go): replace fiber.NewError with SendErrorResponse for handling crash/panics