### PR TITLE
Implement [Internal] [Middleware Utils] CSRF

### DIFF
--- a/backend/internal/middleware/helper.go
+++ b/backend/internal/middleware/helper.go
@@ -406,3 +406,136 @@ func WithStorage(storage fiber.Storage) interface{} {
 		}
 	}
 }
+
+// WithCSRFNext is an option function for NewCSRFMiddleware that sets the Next function to skip the middleware.
+func WithCSRFNext(next func(*fiber.Ctx) bool) func(*csrf.Config) {
+	return func(config *csrf.Config) {
+		config.Next = next
+	}
+}
+
+// WithCSRFKeyLookup is an option function for NewCSRFMiddleware that sets the key lookup for the CSRF token.
+func WithCSRFKeyLookup(keyLookup string) func(*csrf.Config) {
+	return func(config *csrf.Config) {
+		config.KeyLookup = keyLookup
+	}
+}
+
+// WithCSRFCookieName is an option function for NewCSRFMiddleware that sets the name of the CSRF cookie.
+func WithCSRFCookieName(cookieName string) func(*csrf.Config) {
+	return func(config *csrf.Config) {
+		config.CookieName = cookieName
+	}
+}
+
+// WithCSRFCookieDomain is an option function for NewCSRFMiddleware that sets the domain of the CSRF cookie.
+func WithCSRFCookieDomain(cookieDomain string) func(*csrf.Config) {
+	return func(config *csrf.Config) {
+		config.CookieDomain = cookieDomain
+	}
+}
+
+// WithCSRFCookiePath is an option function for NewCSRFMiddleware that sets the path of the CSRF cookie.
+func WithCSRFCookiePath(cookiePath string) func(*csrf.Config) {
+	return func(config *csrf.Config) {
+		config.CookiePath = cookiePath
+	}
+}
+
+// WithCSRFCookieSecure is an option function for NewCSRFMiddleware that sets the secure flag of the CSRF cookie.
+func WithCSRFCookieSecure(cookieSecure bool) func(*csrf.Config) {
+	return func(config *csrf.Config) {
+		config.CookieSecure = cookieSecure
+	}
+}
+
+// WithCSRFCookieHTTPOnly is an option function for NewCSRFMiddleware that sets the HTTP only flag of the CSRF cookie.
+func WithCSRFCookieHTTPOnly(cookieHTTPOnly bool) func(*csrf.Config) {
+	return func(config *csrf.Config) {
+		config.CookieHTTPOnly = cookieHTTPOnly
+	}
+}
+
+// WithCSRFCookieSameSite is an option function for NewCSRFMiddleware that sets the SameSite attribute of the CSRF cookie.
+func WithCSRFCookieSameSite(cookieSameSite string) func(*csrf.Config) {
+	return func(config *csrf.Config) {
+		config.CookieSameSite = cookieSameSite
+	}
+}
+
+// WithCSRFCookieSessionOnly is an option function for NewCSRFMiddleware that sets the session-only flag of the CSRF cookie.
+func WithCSRFCookieSessionOnly(cookieSessionOnly bool) func(*csrf.Config) {
+	return func(config *csrf.Config) {
+		config.CookieSessionOnly = cookieSessionOnly
+	}
+}
+
+// WithCSRFExpiration is an option function for NewCSRFMiddleware that sets the expiration time of the CSRF token.
+func WithCSRFExpiration(expiration time.Duration) func(*csrf.Config) {
+	return func(config *csrf.Config) {
+		config.Expiration = expiration
+	}
+}
+
+// WithCSRFSingleUseToken is an option function for NewCSRFMiddleware that sets the single-use token flag.
+func WithCSRFSingleUseToken(singleUseToken bool) func(*csrf.Config) {
+	return func(config *csrf.Config) {
+		config.SingleUseToken = singleUseToken
+	}
+}
+
+// WithCSRFStorage is an option function for NewCSRFMiddleware that sets the storage for the CSRF middleware.
+func WithCSRFStorage(storage fiber.Storage) func(*csrf.Config) {
+	return func(config *csrf.Config) {
+		config.Storage = storage
+	}
+}
+
+// WithCSRFSession is an option function for NewCSRFMiddleware that sets the session store for the CSRF middleware.
+func WithCSRFSession(session *session.Store) func(*csrf.Config) {
+	return func(config *csrf.Config) {
+		config.Session = session
+	}
+}
+
+// WithCSRFSessionKey is an option function for NewCSRFMiddleware that sets the session key for storing the CSRF token.
+func WithCSRFSessionKey(sessionKey string) func(*csrf.Config) {
+	return func(config *csrf.Config) {
+		config.SessionKey = sessionKey
+	}
+}
+
+// WithCSRFContextKey is an option function for NewCSRFMiddleware that sets the context key for storing the CSRF token.
+func WithCSRFContextKey(contextKey interface{}) func(*csrf.Config) {
+	return func(config *csrf.Config) {
+		config.ContextKey = contextKey
+	}
+}
+
+// WithCSRFKeyGenerator is an option function for NewCSRFMiddleware that sets the key generator function for the CSRF token.
+func WithCSRFKeyGenerator(keyGenerator func() string) func(*csrf.Config) {
+	return func(config *csrf.Config) {
+		config.KeyGenerator = keyGenerator
+	}
+}
+
+// WithCSRFErrorHandler is an option function for NewCSRFMiddleware that sets the error handler for the CSRF middleware.
+func WithCSRFErrorHandler(errorHandler fiber.ErrorHandler) func(*csrf.Config) {
+	return func(config *csrf.Config) {
+		config.ErrorHandler = errorHandler
+	}
+}
+
+// WithCSRFExtractor is an option function for NewCSRFMiddleware that sets the extractor function for retrieving the CSRF token.
+func WithCSRFExtractor(extractor func(*fiber.Ctx) (string, error)) func(*csrf.Config) {
+	return func(config *csrf.Config) {
+		config.Extractor = extractor
+	}
+}
+
+// WithCSRFHandlerContextKey is an option function for NewCSRFMiddleware that sets the context key for storing the CSRF handler.
+func WithCSRFHandlerContextKey(handlerContextKey interface{}) func(*csrf.Config) {
+	return func(config *csrf.Config) {
+		config.HandlerContextKey = handlerContextKey
+	}
+}

--- a/backend/internal/middleware/utils.go
+++ b/backend/internal/middleware/utils.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/cache"
 	"github.com/gofiber/fiber/v2/middleware/cors"
+	"github.com/gofiber/fiber/v2/middleware/csrf"
 	"github.com/gofiber/fiber/v2/middleware/encryptcookie"
 	"github.com/gofiber/fiber/v2/middleware/etag"
 	"github.com/gofiber/fiber/v2/middleware/favicon"
@@ -419,4 +420,23 @@ func NewSessionMiddleware(options ...interface{}) fiber.Handler {
 		// Continue to the next middleware or handler.
 		return c.Next()
 	}
+}
+
+// NewCSRFMiddleware creates a new CSRF middleware with optional custom configuration options.
+func NewCSRFMiddleware(options ...interface{}) fiber.Handler {
+	// Create a new CSRF middleware configuration.
+	config := csrf.Config{}
+
+	// Apply any additional options to the CSRF configuration.
+	for _, option := range options {
+		if optFunc, ok := option.(func(*csrf.Config)); ok {
+			optFunc(&config)
+		}
+	}
+
+	// Create the CSRF middleware with the configured options.
+	csrfMiddleware := csrf.New(config)
+
+	// Return the CSRF middleware.
+	return csrfMiddleware
 }


### PR DESCRIPTION
- [+] feat(middleware): implement NewCSRFMiddleware function
- [+] A new function named NewCSRFMiddleware is added to create a new CSRF middleware with optional custom configuration options. It takes a variadic parameter of type interface{} to allow passing multiple option functions. The function creates a new csrf.Config instance, applies the provided options to the configuration, and returns the CSRF middleware created with the configured options.
- [+] feat(middleware): add option functions for CSRF middleware configuration
- [+] The commit introduces a set of option functions that can be used to customize the configuration of the CSRF middleware. These functions provide a convenient way to set various options such as the Next function, key lookup, cookie properties, expiration, storage, session, context keys, key generator, error handler, and extractor.