### PR TITLE
Fix Style [Internal] [Middleware] [REST APIs Route] Rate Limiter

### DIFF
--- a/backend/internal/middleware/restapis_routes.go
+++ b/backend/internal/middleware/restapis_routes.go
@@ -115,7 +115,8 @@ func registerRESTAPIsRoutes(api fiber.Router, db database.Service) {
 		WithStorage(gopherStorage),
 		WithMax(maxRequestRESTAPIsRateLimiter),
 		WithExpiration(maxExpirationRESTAPIsRateLimiter),
-		WithLimitReached(ratelimiterMsg(MsgRESTAPIsVisitorGotRateLimited)))
+		WithLimitReached(ratelimiterMsg(MsgRESTAPIsVisitorGotRateLimited)),
+	)
 
 	// Register server APIs routes
 	serverAPIs(v1, db, rateLimiterRESTAPIs)


### PR DESCRIPTION
- [+] fix style(middleware): add missing parenthesis for rate limiter options

Note: This looks better in IDE (e.g., vscode)