### PR TITLE
Enhance [pkg] [REST APIs Helper] HTTP Error Response

### DIFF
--- a/backend/pkg/restapis/helper/restapis_error.go
+++ b/backend/pkg/restapis/helper/restapis_error.go
@@ -8,13 +8,15 @@ import "github.com/gofiber/fiber/v2"
 
 // ErrorResponse represents the structure of an error response.
 type ErrorResponse struct {
-	Error string `json:"error"`
+	ErrorCode int    `json:"errorCode"` // rfc9083
+	Error     string `json:"error"`
 }
 
 // SendErrorResponse sends an error response with the specified status code and error message.
 func SendErrorResponse(c *fiber.Ctx, statusCode int, errorMessage string) error {
 	return c.Status(statusCode).JSON(ErrorResponse{
-		Error: errorMessage,
+		ErrorCode: statusCode,
+		Error:     errorMessage,
 	})
 }
 


### PR DESCRIPTION
- [+] feat(restapis): add ErrorCode field to ErrorResponse struct to follow RFC 9083
- [+] test(restapis): add ErrorCode assertions in SendErrorResponse tests
- [+] test(restapis): add TestErrorHandler to test ErrorHandler middleware for handling panics