### PR TITLE
Enhance [pkg] [REST APIs] Health Stats

### DIFF
--- a/backend/pkg/restapis/server/health/db.go
+++ b/backend/pkg/restapis/server/health/db.go
@@ -53,7 +53,7 @@ func DBHandler(db database.Service) fiber.Handler {
 		response := createHealthResponse(health, filter)
 
 		// Log the health status based on the filter
-		logHealthStatus(response, filter)
+		logHealthStatus(c, response, filter)
 
 		// Return the structured health statistics as JSON
 		// Note: The "c.JSON" method uses the sonic package (related to main configuration) for JSON encoding and decoding,


### PR DESCRIPTION
- [+] feat(health): pass fiber context to logHealthStatus and loggers
- [+] refactor(health): update logHealthStatus to return error and handle it in callers
- [+] feat(health): send error response with fiber.StatusServiceUnavailable if MySQL is down
- [+] feat(health): send error response with fiber.StatusServiceUnavailable if Redis is down