### PR TITLE
Implement [Internal] [Middleware Utils] BasicAuth

### DIFF
--- a/backend/internal/middleware/helper.go
+++ b/backend/internal/middleware/helper.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/basicauth"
 	"github.com/gofiber/fiber/v2/middleware/cache"
 	"github.com/gofiber/fiber/v2/middleware/cors"
 	"github.com/gofiber/fiber/v2/middleware/csrf"
@@ -657,5 +658,47 @@ func WithXDownloadOptions(options string) func(*helmet.Config) {
 func WithXPermittedCrossDomain(policies string) func(*helmet.Config) {
 	return func(config *helmet.Config) {
 		config.XPermittedCrossDomain = policies
+	}
+}
+
+// WithUsers is an option function for NewBasicAuthMiddleware that sets the authorized users.
+func WithUsers(users map[string]string) func(*basicauth.Config) {
+	return func(config *basicauth.Config) {
+		config.Users = users
+	}
+}
+
+// WithRealm is an option function for NewBasicAuthMiddleware that sets the authentication realm.
+func WithRealm(realm string) func(*basicauth.Config) {
+	return func(config *basicauth.Config) {
+		config.Realm = realm
+	}
+}
+
+// WithAuthorizer is an option function for NewBasicAuthMiddleware that sets the authorizer function.
+func WithAuthorizer(authorizer func(string, string) bool) func(*basicauth.Config) {
+	return func(config *basicauth.Config) {
+		config.Authorizer = authorizer
+	}
+}
+
+// WithUnauthorized is an option function for NewBasicAuthMiddleware that sets the unauthorized handler.
+func WithUnauthorized(unauthorized fiber.Handler) func(*basicauth.Config) {
+	return func(config *basicauth.Config) {
+		config.Unauthorized = unauthorized
+	}
+}
+
+// WithContextUsername is an option function for NewBasicAuthMiddleware that sets the context key for the authenticated username.
+func WithContextUsername(contextUsername string) func(*basicauth.Config) {
+	return func(config *basicauth.Config) {
+		config.ContextUsername = contextUsername
+	}
+}
+
+// WithContextPassword is an option function for NewBasicAuthMiddleware that sets the context key for the authenticated password.
+func WithContextPassword(contextPassword string) func(*basicauth.Config) {
+	return func(config *basicauth.Config) {
+		config.ContextPassword = contextPassword
 	}
 }

--- a/backend/internal/middleware/utils.go
+++ b/backend/internal/middleware/utils.go
@@ -12,6 +12,7 @@ import (
 	log "h0llyw00dz-template/backend/internal/logger"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/basicauth"
 	"github.com/gofiber/fiber/v2/middleware/cache"
 	"github.com/gofiber/fiber/v2/middleware/cors"
 	"github.com/gofiber/fiber/v2/middleware/csrf"
@@ -496,4 +497,25 @@ func NewHelmetMiddleware(options ...interface{}) fiber.Handler {
 
 	// Return the Helmet middleware.
 	return helmetMiddleware
+}
+
+// NewBasicAuthMiddleware creates a new basic authentication middleware with optional custom configuration options.
+//
+// TODO: Customize this.
+func NewBasicAuthMiddleware(options ...interface{}) fiber.Handler {
+	// Create a new basic authentication middleware configuration.
+	config := basicauth.Config{}
+
+	// Apply any additional options to the basic authentication configuration.
+	for _, option := range options {
+		if optFunc, ok := option.(func(*basicauth.Config)); ok {
+			optFunc(&config)
+		}
+	}
+
+	// Create the basic authentication middleware with the configured options.
+	basicAuthMiddleware := basicauth.New(config)
+
+	// Return the basic authentication middleware.
+	return basicAuthMiddleware
 }


### PR DESCRIPTION
- [+] feat(middleware): implement NewBasicAuthMiddleware function
- [+] Implements the `NewBasicAuthMiddleware` function that creates a new basic authentication middleware with optional custom configuration options. It applies the provided options to the basic authentication configuration and returns the configured middleware.

- [+] feat(middleware): add option functions for configuring basic auth middleware
- [+] The commit introduces several option functions for configuring the basic authentication middleware:
- [+] `WithUsers`: sets the authorized users
- [+] `WithRealm`: sets the authentication realm
- [+] `WithAuthorizer`: sets the authorizer function
- [+] `WithUnauthorized`: sets the unauthorized handler
- [+] `WithContextUsername`: sets the context key for the authenticated username
- [+] `WithContextPassword`: sets the context key for the authenticated password