### PR TITLE
Docs [Internal] [Middleware Utils] BasicAuth

### DIFF
--- a/backend/internal/middleware/utils.go
+++ b/backend/internal/middleware/utils.go
@@ -502,7 +502,7 @@ func NewHelmetMiddleware(options ...interface{}) fiber.Handler {
 // NewBasicAuthMiddleware creates a new basic authentication middleware with optional custom configuration options.
 //
 // TODO: Consider customizing this middleware to support alternative authentication methods like OAuth, cryptocurrency-based authentication,
-// or Single Sign-On (SSO) by modifying the username/password logic to handle session tokens or other authentication mechanisms.
+// or Single Sign-On (SSO) by modifying the username/password logic to handle session tokens or other authentication mechanisms (NOTE: NO JWT and their base standards).
 func NewBasicAuthMiddleware(options ...interface{}) fiber.Handler {
 	// Create a new basic authentication middleware configuration.
 	config := basicauth.Config{}


### PR DESCRIPTION
- [+] refactor(middleware): add note to consider alternative authentication methods in NewBasicAuthMiddleware
- [+] docs(middleware): clarify that JWT and their base standards should not be used for alternative authentication methods in NewBasicAuthMiddleware