### PR TITLE
Refactor [Internal] [Middleware Utils] [CORS] Remove Type Alias

### DIFF
--- a/backend/internal/middleware/helper.go
+++ b/backend/internal/middleware/helper.go
@@ -26,9 +26,6 @@ import (
 	"github.com/google/uuid"
 )
 
-// CORSOption is a function that configures the CORS middleware.
-type CORSOption func(*cors.Config)
-
 // generateGoogleUUIDFromIP generates a deterministic UUID based on the provided IP address.
 func generateGoogleUUIDFromIP(ipAddress string) string {
 	return uuid.NewSHA1(uuid.NameSpaceURL, []byte(ipAddress)).String()
@@ -256,42 +253,42 @@ func appendNonNilHandler(handlers []fiber.Handler, handlerFuncs ...fiber.Handler
 }
 
 // WithAllowOrigins sets the allowed origins for CORS requests.
-func WithAllowOrigins(origins string) CORSOption {
+func WithAllowOrigins(origins string) func(*cors.Config) {
 	return func(config *cors.Config) {
 		config.AllowOrigins = origins
 	}
 }
 
 // WithAllowMethods sets the allowed HTTP methods for CORS requests.
-func WithAllowMethods(methods string) CORSOption {
+func WithAllowMethods(methods string) func(*cors.Config) {
 	return func(config *cors.Config) {
 		config.AllowMethods = methods
 	}
 }
 
 // WithAllowHeaders sets the allowed headers for CORS requests.
-func WithAllowHeaders(headers string) CORSOption {
+func WithAllowHeaders(headers string) func(*cors.Config) {
 	return func(config *cors.Config) {
 		config.AllowHeaders = headers
 	}
 }
 
 // WithExposeHeaders sets the headers that should be exposed to the client.
-func WithExposeHeaders(headers string) CORSOption {
+func WithExposeHeaders(headers string) func(*cors.Config) {
 	return func(config *cors.Config) {
 		config.ExposeHeaders = headers
 	}
 }
 
 // WithAllowCredentials sets whether credentials are allowed for CORS requests.
-func WithAllowCredentials(allow bool) CORSOption {
+func WithAllowCredentials(allow bool) func(*cors.Config) {
 	return func(config *cors.Config) {
 		config.AllowCredentials = allow
 	}
 }
 
 // WithMaxAge sets the maximum age (in seconds) for preflight requests.
-func WithMaxAge(maxAge int) CORSOption {
+func WithMaxAge(maxAge int) func(*cors.Config) {
 	return func(config *cors.Config) {
 		config.MaxAge = maxAge
 	}
@@ -319,7 +316,7 @@ func WithMaxAge(maxAge int) CORSOption {
 //	// Other options...
 //
 //	)
-func WithAllowOriginsFunc(allowOriginsFunc func(string) bool) CORSOption {
+func WithAllowOriginsFunc(allowOriginsFunc func(string) bool) func(*cors.Config) {
 	return func(config *cors.Config) {
 		config.AllowOriginsFunc = allowOriginsFunc
 	}

--- a/backend/internal/middleware/utils.go
+++ b/backend/internal/middleware/utils.go
@@ -171,7 +171,7 @@ func NewRateLimiter(options ...interface{}) fiber.Handler {
 //	WithMaxAge(3600),
 //
 // )
-func NewCORSMiddleware(options ...CORSOption) fiber.Handler {
+func NewCORSMiddleware(options ...interface{}) fiber.Handler {
 	// Note: In the Fiber framework v3, this CORS middleware configuration provides better security and low overhead.
 	// For example, it allows blocking internal IPs by setting `AllowPrivateNetwork` to false (read more: https://docs.gofiber.io/api/middleware/cors).
 	// Create a new CORS middleware configuration with default values
@@ -179,7 +179,9 @@ func NewCORSMiddleware(options ...CORSOption) fiber.Handler {
 
 	// Apply any additional options to the CORS configuration
 	for _, option := range options {
-		option(&config)
+		if optFunc, ok := option.(func(*cors.Config)); ok {
+			optFunc(&config)
+		}
 	}
 
 	// Create the CORS middleware with the configured options


### PR DESCRIPTION
- [+] refactor(middleware): remove CORSOption type and use func(*cors.Config) directly
- [+] The commit removes the CORSOption type and replaces it with the direct usage of func(*cors.Config) in the CORS configuration functions and the NewCORSMiddleware function. This simplifies the code and eliminates the need for a separate type.

- [+] feat(middleware): add type assertion in NewCORSMiddleware to handle func(*cors.Config) options
- [+] The NewCORSMiddleware function is updated to accept options of any type and perform a type assertion to check if each option is of type func(*cors.Config). If the type assertion succeeds, the option is applied to the CORS configuration. This allows for more flexibility in passing options to the middleware.