### PR TITLE
Enhance [Internal] [Middleware Utils] ETag & Favicon

### DIFF
--- a/backend/internal/middleware/helper.go
+++ b/backend/internal/middleware/helper.go
@@ -18,6 +18,8 @@ import (
 	"github.com/gofiber/fiber/v2/middleware/cors"
 	"github.com/gofiber/fiber/v2/middleware/csrf"
 	"github.com/gofiber/fiber/v2/middleware/encryptcookie"
+	"github.com/gofiber/fiber/v2/middleware/etag"
+	"github.com/gofiber/fiber/v2/middleware/favicon"
 	"github.com/gofiber/fiber/v2/middleware/helmet"
 	"github.com/gofiber/fiber/v2/middleware/keyauth"
 	"github.com/gofiber/fiber/v2/middleware/limiter"
@@ -734,5 +736,26 @@ func WithNext(next func(c *fiber.Ctx) bool) interface{} {
 		default:
 			panic(fmt.Sprintf("unsupported config type: %T", config))
 		}
+	}
+}
+
+// WithETagWeak is an option function for NewETagMiddleware that sets the weak ETag flag.
+func WithETagWeak(weak bool) func(*etag.Config) {
+	return func(config *etag.Config) {
+		config.Weak = weak
+	}
+}
+
+// WithFaviconFile is an option function for NewFaviconMiddleware that sets the file path of the favicon.
+func WithFaviconFile(file string) func(*favicon.Config) {
+	return func(config *favicon.Config) {
+		config.File = file
+	}
+}
+
+// WithFaviconURL is an option function for NewFaviconMiddleware that sets the URL path where the favicon will be served.
+func WithFaviconURL(url string) func(*favicon.Config) {
+	return func(config *favicon.Config) {
+		config.URL = url
 	}
 }

--- a/backend/internal/middleware/routes.go
+++ b/backend/internal/middleware/routes.go
@@ -57,7 +57,10 @@ func registerRouteConfigMiddleware(app *fiber.App) {
 
 	// Favicon front end setup
 	// Note: this just an example
-	favicon := NewFaviconMiddleware("./frontend/public/assets/images/favicon.ico", "/favicon.ico")
+	favicon := NewFaviconMiddleware(
+		WithFaviconFile("./frontend/public/assets/images/favicon.ico"),
+		WithFaviconURL("/favicon.ico"),
+	)
 
 	// Recovery middleware setup
 	recoverMiddleware := recover.New(recover.Config{

--- a/backend/internal/middleware/utils.go
+++ b/backend/internal/middleware/utils.go
@@ -191,21 +191,44 @@ func NewCORSMiddleware(options ...interface{}) fiber.Handler {
 	return corsMiddleware
 }
 
-// NewETagMiddleware creates a new ETag middleware with the default configuration.
+// NewETagMiddleware creates a new ETag middleware with the default and optional custom configuration options.
 // It generates strong ETags for response caching and validation.
-func NewETagMiddleware() fiber.Handler {
-	return etag.New(etag.Config{
-		Weak: false,
-	})
+func NewETagMiddleware(options ...interface{}) fiber.Handler {
+	// Create a new ETag middleware configuration.
+	config := etag.Config{}
+
+	// Apply any additional options to the ETag configuration
+	for _, option := range options {
+		if optFunc, ok := option.(func(*etag.Config)); ok {
+			optFunc(&config)
+		}
+	}
+
+	// Create the ETag middleware with the configured options
+	etagMiddleware := etag.New(config)
+
+	// Return the ETag middleware
+	return etagMiddleware
 }
 
 // NewFaviconMiddleware creates a new favicon middleware to serve a favicon file.
 // It takes the file path of the favicon and the URL path where the favicon will be served.
-func NewFaviconMiddleware(filePath, urlPath string) fiber.Handler {
-	return favicon.New(favicon.Config{
-		File: filePath,
-		URL:  urlPath,
-	})
+func NewFaviconMiddleware(options ...interface{}) fiber.Handler {
+	// Create a new favicon middleware configuration with default values
+	config := favicon.Config{}
+
+	// Apply any additional options to the favicon configuration
+	for _, option := range options {
+		if optFunc, ok := option.(func(*favicon.Config)); ok {
+			optFunc(&config)
+		}
+	}
+
+	// Create the favicon middleware with the configured options
+	faviconMiddleware := favicon.New(config)
+
+	// Return the favicon middleware
+	return faviconMiddleware
 }
 
 // NewPprofMiddleware creates a new pprof middleware with a custom path.


### PR DESCRIPTION
- [+] feat(middleware): add option functions for ETag and Favicon middleware
- [+] Introduce `WithETagWeak` option function to set the weak ETag flag in `NewETagMiddleware`
- [+] Add `WithFaviconFile` and `WithFaviconURL` option functions to configure the file path and URL path for `NewFaviconMiddleware`
- [+] Update `NewETagMiddleware` and `NewFaviconMiddleware` to accept and apply the new option functions
- [+] Modify the route configuration to use the new option functions when setting up the Favicon middleware