### PR TITLE
Implement [Internal] [Authentication] [Cryptography] "bcrypt"

### DIFF
--- a/backend/internal/database/auth.go
+++ b/backend/internal/database/auth.go
@@ -8,6 +8,8 @@ import (
 	"database/sql"
 	"errors"
 
+	"h0llyw00dz-template/backend/internal/middleware/authentication/crypto/bcrypt"
+
 	"github.com/gofiber/fiber/v2"
 )
 
@@ -30,14 +32,16 @@ type ServiceAuth interface {
 type serviceAuth struct {
 	db           *sql.DB
 	fiberStorage fiber.Storage
+	bcrypt       bcrypt.Service
 }
 
 // NewServiceAuth creates a new instance of the ServiceAuth interface.
 // It takes a database connection as a parameter and returns a new serviceAuth instance.
-func NewServiceAuth(db *sql.DB, fiberStorage fiber.Storage) ServiceAuth {
+func NewServiceAuth(db *sql.DB, fiberStorage fiber.Storage, bcryptService bcrypt.Service) ServiceAuth {
 	return &serviceAuth{
 		db:           db,
 		fiberStorage: fiberStorage,
+		bcrypt:       bcryptService,
 	}
 }
 

--- a/backend/internal/middleware/authentication/crypto/bcrypt/bcrypt.go
+++ b/backend/internal/middleware/authentication/crypto/bcrypt/bcrypt.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// License: BSD 3-Clause License
+
+package bcrypt
+
+// Service is the interface for the bcrypt password hashing service.
+// It provides methods for password hashing and comparison.
+type Service interface {
+	// HashPassword takes a plaintext password and returns the bcrypt hash of the password.
+	HashPassword(password string) (string, error)
+
+	// ComparePassword compares a plaintext password with the stored bcrypt hash.
+	// It returns true if the password matches the hash, false otherwise.
+	ComparePassword(password, hash string) bool
+}
+
+// Hash is an implementation of the bcrypt password hashing Service interface.
+type Hash struct{}
+
+// New creates a new instance of the bcrypt password hashing service.
+func New() Service {
+	return &Hash{}
+}
+
+// HashPassword takes a plaintext password and returns the bcrypt hash of the password.
+func (s *Hash) HashPassword(password string) (string, error) {
+	return HashPassword(password)
+}
+
+// ComparePassword compares a plaintext password with the stored bcrypt hash.
+// It returns true if the password matches the hash, false otherwise.
+func (s *Hash) ComparePassword(password, hash string) bool {
+	return ComparePassword(password, hash)
+}

--- a/backend/internal/middleware/authentication/crypto/bcrypt/bcrypt_test.go
+++ b/backend/internal/middleware/authentication/crypto/bcrypt/bcrypt_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// License: BSD 3-Clause License
+
+package bcrypt_test
+
+import (
+	"testing"
+
+	"h0llyw00dz-template/backend/internal/middleware/authentication/crypto/bcrypt"
+)
+
+func TestHashPassword(t *testing.T) {
+	password := "password123"
+
+	hashedPassword, err := bcrypt.HashPassword(password)
+	if err != nil {
+		t.Fatalf("Failed to hash password: %v", err)
+	}
+
+	if len(hashedPassword) == 0 {
+		t.Error("Hashed password is empty")
+	}
+}
+
+func TestComparePassword(t *testing.T) {
+	password := "password123"
+	incorrectPassword := "incorrect"
+
+	hashedPassword, err := bcrypt.HashPassword(password)
+	if err != nil {
+		t.Fatalf("Failed to hash password: %v", err)
+	}
+
+	if !bcrypt.ComparePassword(password, hashedPassword) {
+		t.Error("ComparePassword returned false for correct password")
+	}
+
+	if bcrypt.ComparePassword(incorrectPassword, hashedPassword) {
+		t.Error("ComparePassword returned true for incorrect password")
+	}
+}
+
+func TestBcryptService_HashPassword(t *testing.T) {
+	bcryptService := bcrypt.New()
+	password := "password123"
+
+	hashedPassword, err := bcryptService.HashPassword(password)
+	if err != nil {
+		t.Fatalf("Failed to hash password: %v", err)
+	}
+
+	if len(hashedPassword) == 0 {
+		t.Error("Hashed password is empty")
+	}
+}
+
+func TestBcryptService_ComparePassword(t *testing.T) {
+	bcryptService := bcrypt.New()
+	password := "password123"
+	incorrectPassword := "incorrect"
+
+	hashedPassword, err := bcryptService.HashPassword(password)
+	if err != nil {
+		t.Fatalf("Failed to hash password: %v", err)
+	}
+
+	if !bcryptService.ComparePassword(password, hashedPassword) {
+		t.Error("ComparePassword returned false for correct password")
+	}
+
+	if bcryptService.ComparePassword(incorrectPassword, hashedPassword) {
+		t.Error("ComparePassword returned true for incorrect password")
+	}
+}

--- a/backend/internal/middleware/authentication/crypto/bcrypt/compare_password.go
+++ b/backend/internal/middleware/authentication/crypto/bcrypt/compare_password.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// License: BSD 3-Clause License
+
+package bcrypt
+
+import (
+	"golang.org/x/crypto/bcrypt"
+)
+
+// ComparePassword compares a plaintext password with the stored bcrypt hash.
+// It returns true if the password matches the hash, false otherwise.
+func ComparePassword(password, hash string) bool {
+	err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+	return err == nil
+}

--- a/backend/internal/middleware/authentication/crypto/bcrypt/docs.go
+++ b/backend/internal/middleware/authentication/crypto/bcrypt/docs.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// License: BSD 3-Clause License
+
+// Package bcrypt provides a secure way to hash and compare passwords using the bcrypt algorithm.
+// It is suitable for basic authentication and user management when interacting with a database.
+//
+// The package offers a Service interface with methods for hashing passwords and comparing plaintext
+// passwords with stored hashes. It also provides a New function to create a new instance of the
+// bcrypt password hashing service.
+//
+// Usage:
+//
+//  1. Create a new instance of the bcrypt service using the New function:
+//     bcryptService := bcrypt.New()
+//
+//  2. Hash a password using the HashPassword method:
+//     hashedPassword, err := bcryptService.HashPassword(password)
+//     if err != nil {
+//     // Handle the error
+//     }
+//
+//  3. Store the hashed password in the database along with the user's credentials.
+//
+//  4. When a user attempts to log in, retrieve the user's record from the database based on the
+//     provided username or email.
+//
+//  5. Compare the user's entered password with the stored hashed password using the ComparePassword method:
+//     if bcryptService.ComparePassword(enteredPassword, storedHash) {
+//     // Password is correct, authenticate the user
+//     } else {
+//     // Password is incorrect, reject the login attempt
+//     }
+//
+// Note: It is important to store only the hashed passwords in the database and never store plaintext passwords.
+// The bcrypt package ensures that the password hashing is secure and resilient against various attacks.
+//
+// The package uses a default cost factor of 10 for the bcrypt algorithm, which provides a good balance
+// between security and performance. However, you can adjust the cost factor by modifying the
+// bcrypt.DefaultCost constant in the HashPassword function if needed.
+//
+// It is recommended to use this package in combination with other security measures, such as HTTPS/TLS
+// for secure communication, secure session management, and protection against common vulnerabilities like
+// SQL injection and cross-site scripting (XSS).
+//
+// For more information about the bcrypt algorithm and its security properties, refer to the
+// official Go documentation: https://pkg.go.dev/golang.org/x/crypto/bcrypt
+// REF: https://gowebexamples.com/password-hashing/
+package bcrypt

--- a/backend/internal/middleware/authentication/crypto/bcrypt/hash_password.go
+++ b/backend/internal/middleware/authentication/crypto/bcrypt/hash_password.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// License: BSD 3-Clause License
+
+package bcrypt
+
+import "golang.org/x/crypto/bcrypt"
+
+// HashPassword takes a plaintext password and returns the bcrypt hash of the password.
+func HashPassword(password string) (string, error) {
+	// Generate a salt with a default cost of 10
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+	return string(hash), nil
+}


### PR DESCRIPTION
- [+] feat(database): add bcrypt service for password hashing and comparison
- [+] Introduce a new bcrypt service in the `middleware/authentication/crypto/bcrypt` package
- [+] Implement `HashPassword` and `ComparePassword` functions for secure password hashing and comparison
- [+] Add tests for the bcrypt service and its functions
- [+] Update the `ServiceAuth` interface and `serviceAuth` struct to include the bcrypt service
- [+] Modify the `NewServiceAuth` function to accept the bcrypt service as a parameter
- [+] Update the `New` function in `database/mysql_redis.go` to initialize the bcrypt service and pass it to `NewServiceAuth`
- [+] Add documentation for the bcrypt package explaining its usage and security considerations