### PR TITLE
Refactor [Internal] [Middleware Utils] Session Middleware Logic

### DIFF
--- a/backend/internal/middleware/utils.go
+++ b/backend/internal/middleware/utils.go
@@ -444,9 +444,6 @@ func NewSessionMiddleware(options ...interface{}) fiber.Handler {
 			cleanupInterval = opt
 		case string:
 			contextKey = opt
-			// Instead of panic/crash, return error it's better
-		default:
-			log.LogErrorf("Unknown option type passed to NewSessionMiddleware: %T", opt)
 		}
 	}
 


### PR DESCRIPTION
- [+] refactor(middleware): remove error logging for unknown option type in NewSessionMiddleware

Note: This is unnecessary `default:` when all options are passed by default configuration, as it keeps showing `Unknown func`. Therefore, it's better to remove it.