### PR TITLE
Refactor [Internal] [Middleware Helper] Redirect & Rewrite Rules

### DIFF
--- a/backend/internal/middleware/restapis_routes.go
+++ b/backend/internal/middleware/restapis_routes.go
@@ -93,7 +93,7 @@ func registerRESTAPIsRoutes(api fiber.Router, db database.Service) {
 	// This is one of the reasons why I like Go. For example, when I'm lazy to implement something from scratch,
 	// I can just use a package that is already stable then build on top of it using higher-order functions.
 	redirectMiddleware := NewRedirectMiddleware(
-		WithRedirectRules(map[string]string{
+		WithRules(map[string]string{
 			"v1": "/",
 		}),
 		WithRedirectStatusCode(fiber.StatusMovedPermanently),


### PR DESCRIPTION
- [+] refactor(middleware): merge WithRewrite and WithRedirectRules into a single WithRules option function
- [+] The commit message explains that the changes in the code are refactoring the middleware package by merging the `WithRewrite` and `WithRedirectRules` option functions into a single `WithRules` option function. This new `WithRules` function can be used to set the rewrite or redirect rules for the Rewrite or Redirect middleware, respectively.