### PR TITLE
Docs [Internal] [Database Initialization] Spinners Bubble Tea

### DIFF
--- a/backend/internal/database/mysql_redis.go
+++ b/backend/internal/database/mysql_redis.go
@@ -180,7 +180,7 @@ func New() Service {
 	}
 
 	// Create new spinner models
-	// Note: For the best experience, use a terminal that supports ANSI escape sequences, such as zsh (unix) or bash.
+	// Note: For the best experience, use a terminal that supports ANSI escape sequences, such as zsh (e.g, in priv8 unix server) or bash.
 	// Also note that this won't work and will fail if this repo is running on a cloud service such as Heroku because it requires "/dev/tty",
 	// And I won't fix it, because the issue is related to the cloud provider, not the Go code here.
 	dotSpinner := spinner.New()


### PR DESCRIPTION
- [+] docs(mysql_redis.go): clarify that zsh is available on priv8 unix server for the best spinner experience