### PR TITLE
Docs [Internal] [Database Initialization] Spinner Bubble Tea

### DIFF
--- a/backend/internal/database/setup.go
+++ b/backend/internal/database/setup.go
@@ -285,6 +285,7 @@ func (m model) Init() tea.Cmd {
 // Update updates the model based on the received message.
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	// TODO: Remove this "tea.KeyMsg" case because "tea.Batch" is guaranteed in advanced use cases (e.g., use with spinner.Tick)
 	case tea.KeyMsg:
 		if msg.Type == tea.KeyCtrlC {
 			return m, tea.Quit


### PR DESCRIPTION
- [+] refactor(setup.go): remove redundant tea.KeyMsg case in Update method