### PR TITLE
Remove [Internal] [Database Initialization] [Spinner] "tea.KeyMsg"

### DIFF
--- a/backend/internal/database/setup.go
+++ b/backend/internal/database/setup.go
@@ -285,11 +285,6 @@ func (m model) Init() tea.Cmd {
 // Update updates the model based on the received message.
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
-	// TODO: Remove this "tea.KeyMsg" case because "tea.Batch" is guaranteed in advanced use cases (e.g., use with spinner.Tick)
-	case tea.KeyMsg:
-		if msg.Type == tea.KeyCtrlC {
-			return m, tea.Quit
-		}
 	case spinner.TickMsg:
 		var cmds []tea.Cmd
 		dotSpinner, cmd := m.dotSpinner.Update(msg)


### PR DESCRIPTION
- [+] refactor(setup.go): remove unnecessary tea.KeyMsg case in Update method

Note: This should work fine and be safe. It won't cause any hangs or deadlocks, even when waiting for a response from the server while connecting (on my way) to the database in this goroutine. Most databases already have a default timeout set in their configuration. If wanting to explicitly set a timeout, it must be set in the server configuration before this goroutine starts connecting to the database.