### PR TITLE
Refactor Fiber Prometheus Middleware

### DIFF
--- a/backend/internal/middleware/utils.go
+++ b/backend/internal/middleware/utils.go
@@ -12,7 +12,6 @@ import (
 
 	log "h0llyw00dz-template/backend/internal/logger"
 
-	"github.com/ansrivas/fiberprometheus/v2"
 	"github.com/gofiber/contrib/swagger"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/adaptor"
@@ -33,7 +32,6 @@ import (
 	"github.com/gofiber/fiber/v2/middleware/session"
 	"github.com/gofiber/fiber/v2/utils"
 	"github.com/google/uuid"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // NewCacheMiddleware creates a new cache middleware with optional custom configuration options.
@@ -660,77 +658,4 @@ func ConvertRequestMiddleware(forServer bool, contextKey ...string) fiber.Handle
 		c.Locals(key, req)
 		return c.Next()
 	}
-}
-
-// NewPrometheusMiddleware creates a new Prometheus middleware with optional custom configuration options.
-//
-// Example usage:
-//
-//	app := fiber.New()
-//
-//	// Create a new Prometheus middleware with a service name
-//	prometheusMiddleware := NewPrometheusMiddleware("my-service")
-//
-//	// Create a new Prometheus middleware with a service name and namespace
-//	prometheusMiddleware := NewPrometheusMiddleware("my-service", "my-namespace")
-//
-//	// Create a new Prometheus middleware with a service name, namespace, and subsystem
-//	prometheusMiddleware := NewPrometheusMiddleware("my-service", "my-namespace", "my-subsystem")
-//
-//	// Create a new Prometheus middleware with a service name and custom labels
-//	prometheusMiddleware := NewPrometheusMiddleware("my-service", map[string]string{
-//		"custom_label1": "custom_value1",
-//		"custom_label2": "custom_value2",
-//	})
-//
-//	// Create a new Prometheus middleware with a service name, namespace, subsystem, and custom labels
-//	prometheusMiddleware := NewPrometheusMiddleware("my-service", "my-namespace", "my-subsystem", map[string]string{
-//		"custom_label1": "custom_value1",
-//		"custom_label2": "custom_value2",
-//	})
-//
-//	// Create a new Prometheus middleware with a custom Prometheus registry
-//	customRegistry := prometheus.NewRegistry()
-//	prometheusMiddleware := NewPrometheusMiddleware("my-service", customRegistry)
-//
-//	// Register the Prometheus middleware at a specific path
-//	prometheusMiddleware.RegisterAt(app, "/metrics")
-//
-//	// Use the Prometheus middleware
-//	app.Use(prometheusMiddleware.Middleware)
-//
-// TODO: Move this to the server package, as it would be better used with the mounted app/path.
-func NewPrometheusMiddleware(serviceName string, options ...interface{}) *fiberprometheus.FiberPrometheus {
-	var registry *prometheus.Registry
-	var namespace, subsystem string
-	var labels map[string]string
-
-	// Extract namespace, subsystem, labels, and registry from the options.
-	for _, option := range options {
-		switch opt := option.(type) {
-		case *prometheus.Registry:
-			registry = opt
-		case string:
-			if namespace == "" {
-				namespace = opt
-			} else if subsystem == "" {
-				subsystem = opt
-			}
-		case map[string]string:
-			labels = opt
-		}
-	}
-
-	// Create a new Prometheus instance based on the provided options.
-	var prometheus *fiberprometheus.FiberPrometheus
-	if registry != nil {
-		prometheus = fiberprometheus.NewWithRegistry(registry, serviceName, namespace, subsystem, labels)
-	} else if labels != nil {
-		prometheus = fiberprometheus.NewWithLabels(labels, namespace, subsystem)
-	} else {
-		prometheus = fiberprometheus.NewWith(serviceName, namespace, subsystem)
-	}
-
-	// Return the Prometheus middleware.
-	return prometheus
 }

--- a/backend/internal/server/k8s/docs.go
+++ b/backend/internal/server/k8s/docs.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// License: BSD 3-Clause License
+
+// Package k8s provides functionality for integrating with Kubernetes.
+//
+// This package contains subpackages and modules that are specific to Kubernetes-related
+// features and configurations. It aims to simplify the integration of the application
+// with Kubernetes by providing utilities, handlers, and middleware.
+//
+// Subpackages:
+//
+//   - metrics: Contains code related to metrics and monitoring in the context of Kubernetes.
+//     It provides middleware and handlers for exposing metrics to Prometheus.
+//
+// Example usage of the metrics subpackage:
+//
+//	// Create a new Prometheus middleware with a service name
+//	prometheusMiddleware := metrics.NewPrometheusMiddleware("my-service")
+//
+//	// Create a new Prometheus middleware with a service name and namespace
+//	prometheusMiddleware := metrics.NewPrometheusMiddleware("my-service", "my-namespace")
+//
+//	// Create a new Prometheus middleware with a service name, namespace, and subsystem
+//	prometheusMiddleware := metrics.NewPrometheusMiddleware("my-service", "my-namespace", "my-subsystem")
+//
+//	// Create a new Prometheus middleware with a service name and custom labels
+//	prometheusMiddleware := metrics.NewPrometheusMiddleware("my-service", map[string]string{
+//		"custom_label1": "custom_value1",
+//		"custom_label2": "custom_value2",
+//	})
+//
+//	// Create a new Prometheus middleware with a service name, namespace, subsystem, and custom labels
+//	prometheusMiddleware := metrics.NewPrometheusMiddleware("my-service", "my-namespace", "my-subsystem", map[string]string{
+//		"custom_label1": "custom_value1",
+//		"custom_label2": "custom_value2",
+//	})
+//
+//	// Create a new Prometheus middleware with a custom Prometheus registry
+//	customRegistry := prometheus.NewRegistry()
+//	prometheusMiddleware := metrics.NewPrometheusMiddleware("my-service", customRegistry)
+//
+//	// Register the Prometheus middleware at a specific path
+//	prometheusMiddleware.RegisterAt(app, "/metrics")
+//
+//	// Use the Prometheus middleware
+//	app.Use(prometheusMiddleware.Middleware)
+//
+// The metrics subpackage provides the NewPrometheusMiddleware function for creating a new
+// Prometheus middleware with optional custom configuration options. It allows creating a middleware
+// with a service name, namespace, subsystem, custom labels, and a custom Prometheus registry.
+//
+// As more subpackages or modules are added to the k8s package, this documentation can be extended
+// to provide an overview of their functionality and usage examples.
+//
+// Note: The k8s package and its subpackages are intended to be used in conjunction with
+// a Kubernetes environment. Ensure that the necessary Kubernetes dependencies and
+// configurations are set up in the project.
+package k8s

--- a/backend/internal/server/k8s/metrics/prometheus.go
+++ b/backend/internal/server/k8s/metrics/prometheus.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// License: BSD 3-Clause License
+
+package metrics
+
+import (
+	"github.com/ansrivas/fiberprometheus/v2"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// NewPrometheusMiddleware creates a new Prometheus middleware with optional custom configuration options.
+func NewPrometheusMiddleware(serviceName string, options ...interface{}) *fiberprometheus.FiberPrometheus {
+	var registry *prometheus.Registry
+	var namespace, subsystem string
+	var labels map[string]string
+
+	// Extract namespace, subsystem, labels, and registry from the options.
+	for _, option := range options {
+		switch opt := option.(type) {
+		case *prometheus.Registry:
+			registry = opt
+		case string:
+			if namespace == "" {
+				namespace = opt
+			} else if subsystem == "" {
+				subsystem = opt
+			}
+		case map[string]string:
+			labels = opt
+		}
+	}
+
+	// Create a new Prometheus instance based on the provided options.
+	var prometheus *fiberprometheus.FiberPrometheus
+	if registry != nil {
+		prometheus = fiberprometheus.NewWithRegistry(registry, serviceName, namespace, subsystem, labels)
+	} else if labels != nil {
+		prometheus = fiberprometheus.NewWithLabels(labels, namespace, subsystem)
+	} else {
+		prometheus = fiberprometheus.NewWith(serviceName, namespace, subsystem)
+	}
+
+	// Return the Prometheus middleware.
+	return prometheus
+}

--- a/backend/internal/server/mount_routes.go
+++ b/backend/internal/server/mount_routes.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// License: BSD 3-Clause License
+
+package server
+
+import (
+	"h0llyw00dz-template/backend/internal/server/k8s/metrics"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// MountPrometheusMiddlewareHandler returns a Fiber handler that sets up the Prometheus middleware.
+func MountPrometheusMiddlewareHandler(path, serviceName string, options ...interface{}) fiber.Handler {
+	prometheus := metrics.NewPrometheusMiddleware(serviceName, options...)
+	return func(c *fiber.Ctx) error {
+		prometheus.RegisterAt(c.App(), path)
+		c.App().Use(prometheus.Middleware)
+		return c.Next()
+	}
+}

--- a/backend/internal/server/register_routes.go
+++ b/backend/internal/server/register_routes.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// License: BSD 3-Clause License
+
+package server
+
+import "h0llyw00dz-template/backend/internal/server/k8s/metrics"
+
+// RegisterRoutesPrometheus registers the Prometheus middleware at the specified path.
+func (s *FiberServer) RegisterRoutesPrometheus(path string, serviceName string, options ...interface{}) {
+	prometheus := metrics.NewPrometheusMiddleware(serviceName, options...)
+	prometheus.RegisterAt(s.app, path)
+	s.app.Use(prometheus.Middleware)
+}


### PR DESCRIPTION
- [+] refactor(middleware): remove NewPrometheusMiddleware function from utils.go
- [+] feat(k8s): add k8s package with metrics subpackage for Kubernetes-related functionality
- [+] feat(k8s/metrics): add NewPrometheusMiddleware function for creating Prometheus middleware
- [+] feat(server): add MountPrometheusMiddlewareHandler function for mounting Prometheus middleware
- [+] feat(server): add RegisterRoutesPrometheus method to FiberServer for registering Prometheus middleware
- [+] docs(k8s): add package documentation for k8s package and its subpackages