### PR TITLE
Docs [Internal] [Server] Update Documentation]

### DIFF
--- a/backend/internal/server/mount_routes.go
+++ b/backend/internal/server/mount_routes.go
@@ -11,6 +11,27 @@ import (
 )
 
 // MountPrometheusMiddlewareHandler returns a Fiber handler that sets up the Prometheus middleware.
+//
+// This function provides a flexible way to mount the Prometheus middleware as a Fiber handler.
+// It allows you to specify the path where the Prometheus metrics will be exposed and the service name
+// for labeling the metrics. You can also provide additional options for configuring the middleware.
+//
+// The returned handler function mounts the Prometheus middleware at the specified path and adds it to
+// the application's middleware stack. It can be used in scenarios where you want to conditionally mount
+// the Prometheus middleware based on certain conditions or routes.
+//
+// Note: This approach is different from "RegisterRoutesPrometheus" as it returns a Fiber handler
+// instead of directly registering the middleware on the FiberServer instance.
+//
+// Parameters:
+//
+//	path: The path where the Prometheus metrics will be exposed.
+//	serviceName: The name of the service for labeling the metrics.
+//	options: Optional parameters for configuring the Prometheus middleware.
+//
+// Returns:
+//
+//	A Fiber handler function that mounts the Prometheus middleware.
 func MountPrometheusMiddlewareHandler(path, serviceName string, options ...interface{}) fiber.Handler {
 	prometheus := metrics.NewPrometheusMiddleware(serviceName, options...)
 	return func(c *fiber.Ctx) error {

--- a/backend/internal/server/register_routes.go
+++ b/backend/internal/server/register_routes.go
@@ -7,6 +7,17 @@ package server
 import "h0llyw00dz-template/backend/internal/server/k8s/metrics"
 
 // RegisterRoutesPrometheus registers the Prometheus middleware at the specified path.
+//
+// This method is a convenience function defined on the FiberServer struct. It directly registers
+// the Prometheus middleware at the specified path and adds it to the application's middleware stack.
+//
+// It is a straightforward approach if you want to register the Prometheus middleware globally for all routes.
+// The method assumes the existence of a Fiber application instance and is called directly on the FiberServer instance.
+//
+// Parameters:
+//    path: The path where the Prometheus metrics will be exposed.
+//    serviceName: The name of the service for labeling the metrics.
+//    options: Optional parameters for configuring the Prometheus middleware.
 func (s *FiberServer) RegisterRoutesPrometheus(path string, serviceName string, options ...interface{}) {
 	prometheus := metrics.NewPrometheusMiddleware(serviceName, options...)
 	prometheus.RegisterAt(s.app, path)


### PR DESCRIPTION
- [+] docs(server): add documentation for MountPrometheusMiddlewareHandler function
- [+] The added documentation provides a detailed explanation of the MountPrometheusMiddlewareHandler function, including its purpose, flexibility, and usage. It describes the parameters and return value of the function, as well as how it differs from the RegisterRoutesPrometheus approach.
- [+] docs(server): add documentation for RegisterRoutesPrometheus method
- [+] The added documentation explains the purpose and usage of the RegisterRoutesPrometheus method defined on the FiberServer struct. It highlights that this method is a convenience function for directly registering the Prometheus middleware globally for all routes.