### PR TITLE
Another Testing When HMAC is enabled

### DIFF
--- a/backend/internal/middleware/authentication/crypto/hybrid/hybrid_test.go
+++ b/backend/internal/middleware/authentication/crypto/hybrid/hybrid_test.go
@@ -132,7 +132,7 @@ func TestStreamEncryptDecrypt(t *testing.T) {
 
 	_, err = rand.Read(chachaKey)
 	if err != nil {
-		t.Fatalf("Failed to generate ChaCha20-Poly1305 key: %v", err)
+		t.Fatalf("Failed to generate XChaCha20-Poly1305 key: %v", err)
 	}
 
 	// Test cases
@@ -196,7 +196,7 @@ func TestHybridEncryptDecryptStream(t *testing.T) {
 
 	_, err = rand.Read(chachaKey)
 	if err != nil {
-		t.Fatalf("Failed to generate ChaCha20-Poly1305 key: %v", err)
+		t.Fatalf("Failed to generate XChaCha20-Poly1305 key: %v", err)
 	}
 
 	// Create an instance of the stream encryption service
@@ -287,7 +287,7 @@ func TestHybridEncryptDecryptStreamLargeData(t *testing.T) {
 
 	_, err = rand.Read(chachaKey)
 	if err != nil {
-		t.Fatalf("Failed to generate ChaCha20-Poly1305 key: %v", err)
+		t.Fatalf("Failed to generate XChaCha20-Poly1305 key: %v", err)
 	}
 
 	// Create an instance of the stream encryption service

--- a/backend/internal/middleware/authentication/crypto/hybrid/stream/benchmark_test.go
+++ b/backend/internal/middleware/authentication/crypto/hybrid/stream/benchmark_test.go
@@ -24,7 +24,7 @@ func BenchmarkHybridEncryptDecryptStream(b *testing.B) {
 
 	_, err = rand.Read(chachaKey)
 	if err != nil {
-		b.Fatalf("Failed to generate ChaCha20-Poly1305 key: %v", err)
+		b.Fatalf("Failed to generate XChaCha20-Poly1305 key: %v", err)
 	}
 
 	// Create a new Stream instance.
@@ -75,7 +75,7 @@ func BenchmarkHybridEncryptDecryptStreamWithHMAC(b *testing.B) {
 
 	_, err = rand.Read(chachaKey)
 	if err != nil {
-		b.Fatalf("Failed to generate ChaCha20-Poly1305 key: %v", err)
+		b.Fatalf("Failed to generate XChaCha20-Poly1305 key: %v", err)
 	}
 
 	// Create a new Stream instance.


### PR DESCRIPTION
- [+] refactor(hybrid_test.go): update error messages to mention XChaCha20-Poly1305 instead of ChaCha20-Poly1305
- [+] refactor(stream/benchmark_test.go): update error messages to mention XChaCha20-Poly1305 instead of ChaCha20-Poly1305
- [+] refactor(stream/stream_test.go): update comments and error messages to mention XChaCha20-Poly1305 instead of ChaCha20-Poly1305
- [+] test(stream/stream_test.go): add test case for decryption failure when encrypted data has been compromised