### PR TITLE
Fix EOF in Testing HMAC Modify compromised data

### DIFF
--- a/backend/internal/middleware/authentication/crypto/hybrid/stream/stream_test.go
+++ b/backend/internal/middleware/authentication/crypto/hybrid/stream/stream_test.go
@@ -286,7 +286,7 @@ func TestHybridEncryptDecryptStreamWithHMACHasBeenCompromised(t *testing.T) {
 	// Simulate unauthorized modification of the encrypted data.
 	//
 	// Let's say this Data has been Compromised.
-	encryptedData[0] ^= 0xFF // Flip the first byte of the encrypted data.
+	encryptedData[1] ^= 0xFF // Flip the first byte of the encrypted data.
 
 	// Decrypt the data without calculating the HMAC digest (skipping step 2 and 3).
 	decryptedBuffer := new(bytes.Buffer)


### PR DESCRIPTION
- [+] test(stream_test.go): modify compromised data index in TestHybridEncryptDecryptStreamWithHMACHasBeenCompromised