### PR TITLE
Docs [Crypto] [Hybrid Scheme] Update Comments

### DIFF
--- a/backend/internal/middleware/authentication/crypto/hybrid/stream/decrypt_stream.go
+++ b/backend/internal/middleware/authentication/crypto/hybrid/stream/decrypt_stream.go
@@ -10,6 +10,9 @@ import (
 
 // Decrypt reads from the input stream, decrypts the data using XChaCha20-Poly1305 and AES-CTR,
 // verifies the HMAC if enabled, and writes it to the output stream.
+//
+// Note: This function requires a builder for the output, such as a string builder, rune builder, or byte builder,
+// since it performs low-level operations on I/O primitives.
 func (s *Stream) Decrypt(input io.Reader, output io.Writer) error {
 	for {
 		chunk, err := s.readAndDecryptChunk(input)

--- a/backend/internal/middleware/authentication/crypto/hybrid/stream/encrypt_stream.go
+++ b/backend/internal/middleware/authentication/crypto/hybrid/stream/encrypt_stream.go
@@ -10,6 +10,9 @@ import (
 
 // Encrypt reads from the input stream, encrypts the data using AES-CTR and XChaCha20-Poly1305,
 // calculates the HMAC if enabled, and writes it to the output stream.
+//
+// Note: This function requires a builder for the output, such as a string builder, rune builder, or byte builder,
+// since it performs low-level operations on I/O primitives.
 func (s *Stream) Encrypt(input io.Reader, output io.Writer) error {
 	chunk := make([]byte, chunkSize)
 	for {


### PR DESCRIPTION
- [+] docs(crypto): add note about output builder requirement for Decrypt and Encrypt stream functions
- [+] The added comments clarify that the Decrypt and Encrypt functions in the hybrid stream package require a builder for the output, such as a string builder, rune builder, or byte builder, since they perform low-level operations on I/O primitives.