### PR TITLE
Test [Crypto] [Hybrid Scheme] HMAC Digest Validation

### DIFF
--- a/backend/internal/middleware/authentication/crypto/hybrid/stream/stream_test.go
+++ b/backend/internal/middleware/authentication/crypto/hybrid/stream/stream_test.go
@@ -7,6 +7,7 @@ package stream_test
 import (
 	"bytes"
 	"crypto/rand"
+	"crypto/subtle"
 	"errors"
 	"io"
 	"testing"
@@ -269,6 +270,9 @@ func TestHybridEncryptDecryptStreamWithHMAC(t *testing.T) {
 	}
 }
 
+// Let's Say this test simulates a scenario where the encrypted data buffer is vulnerable to a buffer overflow attack,
+// which is exploitable in most languages (e.g., C/C++, Assembly, Python, Java, Ruby) but not in Go.
+// Go is considered safe and suitable for cryptographic operations because it provides built-in protection against buffer overflow vulnerabilities.
 func TestHybridEncryptDecryptStreamWithHMACHasBeenCompromised(t *testing.T) {
 	// Generate random keys for AES and XChaCha20-Poly1305.
 	aesKey := make([]byte, 32)    // AES-256 requires a 32-byte key.
@@ -715,6 +719,9 @@ func TestHybridDecryptStreamEncryptedChunkSizeMismatch(t *testing.T) {
 	}
 }
 
+// Let's Say this test simulates a scenario where the encrypted data buffer is vulnerable to a buffer overflow attack,
+// which is exploitable in most languages (e.g., C/C++, Assembly, Python, Java, Ruby) but not in Go.
+// Go is considered safe and suitable for cryptographic operations because it provides built-in protection against buffer overflow vulnerabilities.
 func TestHybridEncryptDecryptStreamHasBeenCompromised(t *testing.T) {
 	// Generate random keys for AES and XChaCha20-Poly1305.
 	aesKey := make([]byte, 32)    // AES-256 requires a 32-byte key.
@@ -770,5 +777,81 @@ func TestHybridEncryptDecryptStreamHasBeenCompromised(t *testing.T) {
 	decryptedData := decryptedBuffer.Bytes()
 	if bytes.Equal(decryptedData, plaintext) {
 		t.Errorf("Decrypted data matches original plaintext despite unauthorized modification.")
+	}
+}
+
+func TestHybridEncryptDecryptStreamWithHMACDigestInvalidkey(t *testing.T) {
+	// Generate random keys for AES and XChaCha20-Poly1305.
+	aesKey := make([]byte, 32)    // AES-256 requires a 32-byte key.
+	chachaKey := make([]byte, 32) // XChaCha20-Poly1305 uses a 32-byte key.
+
+	_, err := rand.Read(aesKey)
+	if err != nil {
+		t.Fatalf("Failed to generate AES key: %v", err)
+	}
+
+	_, err = rand.Read(chachaKey)
+	if err != nil {
+		t.Fatalf("Failed to generate XChaCha20-Poly1305 key: %v", err)
+	}
+
+	// Create a new Stream instance.
+	s, err := stream.New(aesKey, chachaKey)
+	if err != nil {
+		t.Fatalf("Failed to create Stream instance: %v", err)
+	}
+
+	// Generate a random HMAC key.
+	hmacKey := make([]byte, 32)
+	_, err = rand.Read(hmacKey)
+	if err != nil {
+		t.Fatalf("Failed to generate HMAC key: %v", err)
+	}
+
+	// Enable HMAC authentication.
+	s.EnableHMAC(hmacKey)
+
+	// Simulate plaintext data to encrypt.
+	plaintext := []byte("Hello, World! This is a test of the hybrid encryption system with the wrong HMAC key.")
+
+	// Encrypt the data.
+	inputBuffer := bytes.NewBuffer(plaintext)
+	encryptedBuffer := new(bytes.Buffer)
+	err = s.Encrypt(inputBuffer, encryptedBuffer)
+	if err != nil {
+		t.Fatalf("Failed to encrypt data: %v", err)
+	}
+
+	// Ensure the encrypted data buffer's read position is reset to the beginning.
+	encryptedData := encryptedBuffer.Bytes()
+	encryptedBuffer = bytes.NewBuffer(encryptedData)
+
+	// Calculate the HMAC digest of the encrypted data.
+	hmacDigest, err := s.Digest(bytes.NewReader(encryptedData))
+	if err != nil {
+		t.Fatalf("Failed to calculate HMAC digest: %v", err)
+	}
+
+	// Generate a different HMAC key.
+	wrongHMACKey := make([]byte, 32)
+	_, err = rand.Read(wrongHMACKey)
+	if err != nil {
+		t.Fatalf("Failed to generate wrong HMAC key: %v", err)
+	}
+
+	// Digest the data using the wrong HMAC key.
+	s.EnableHMAC(wrongHMACKey)
+
+	// Verify the HMAC digest.
+	encryptedBuffer = bytes.NewBuffer(encryptedData)
+	calculatedHMACDigest, err := s.Digest(encryptedBuffer)
+	if err != nil {
+		t.Fatalf("Failed to calculate HMAC digest for verification: %v", err)
+	}
+
+	if subtle.ConstantTimeCompare(calculatedHMACDigest, hmacDigest) == 1 {
+		t.Errorf("HMAC digest verification succeeded with the wrong HMAC key.")
+	} else {
+		t.Logf("HMAC digest verification failed as expected %x, Got: %x", hmacDigest, calculatedHMACDigest)
 	}
 }


### PR DESCRIPTION
- [+] test(stream): add test case for compromised encrypted data buffer
- [+] test(stream): add test case for invalid HMAC key in digest verification
- [+] refactor(stream_test): import subtle package for constant time comparison