### PR TITLE
Improve [Crypto] [Hybrid Scheme] Min Chunk Buffer

### DIFF
--- a/backend/internal/middleware/authentication/crypto/hybrid/stream/chunk.go
+++ b/backend/internal/middleware/authentication/crypto/hybrid/stream/chunk.go
@@ -21,6 +21,7 @@ const (
 	// TODO: Do we really need to increase this since the current size is still secure?
 	aesNonceSize = 16
 	chunkSize    = 1024
+	minChunkBuf  = 2
 )
 
 // encryptChunk encrypts a single chunk using AES-CTR and XChaCha20-Poly1305.
@@ -174,9 +175,9 @@ func (s *Stream) writeChunk(encryptedChunk, chachaNonce []byte, output io.Writer
 // readChunkMetadata reads the chunk size and XChaCha20-Poly1305 nonce from the input stream.
 func (s *Stream) readChunkMetadata(input io.Reader) (uint16, []byte, error) {
 	chunkSizeBuf := make([]byte, 2)
-	if _, err := io.ReadFull(input, chunkSizeBuf); err != nil {
+	if _, err := io.ReadAtLeast(input, chunkSizeBuf, minChunkBuf); err != nil {
 		if err == io.ErrUnexpectedEOF {
-			return 0, nil, errors.New("XChacha20Poly1305: Unexpected Chunk Size")
+			return 0, nil, errors.New("XChacha20Poly1305: Unexpected Chunk Buffer Size")
 		}
 		return 0, nil, err
 	}

--- a/backend/internal/middleware/authentication/crypto/hybrid/stream/stream_test.go
+++ b/backend/internal/middleware/authentication/crypto/hybrid/stream/stream_test.go
@@ -896,15 +896,19 @@ func TestDecryptUnexpectedChunk(t *testing.T) {
 
 	// Test case: Decrypt encrypted data with an unexpected chunk
 	invalidEncryptedData := []byte("invalid-encrypted-data")
-	invalidEncryptedInput := bytes.NewReader(invalidEncryptedData)
+	shortBufferSize := 1
 	decryptedOutput.Reset()
+	decryptedOutput.Grow(shortBufferSize)
+	invalidEncryptedInput := bytes.NewReader(invalidEncryptedData[:1])
 
 	err = s.Decrypt(invalidEncryptedInput, &decryptedOutput)
 	if err == nil {
-		t.Error("Expected an error EOF for invalid encrypted data, but got nil")
+		t.Errorf("Expected error due to buffer too short, but got nil.")
+	} else if err.Error() != "XChacha20Poly1305: Unexpected Chunk Buffer Size" {
+		t.Errorf("Expected error message 'XChacha20Poly1305: Unexpected Chunk Buffer Size', but got: %v", err)
+	} else {
+		t.Logf("Decryption failed as expected: %v", err)
 	}
-
-	t.Logf("Decryption failed as expected: %v", err)
 }
 
 func TestHybridDecryptStreamXChaCha20NonceSizeXTooShort(t *testing.T) {


### PR DESCRIPTION
- [+] refactor(stream): change error message for unexpected chunk size
- [+] Previously, the error message for an unexpected chunk size was "XChacha20Poly1305: Unexpected Chunk Size". This has been updated to "XChacha20Poly1305: Unexpected Chunk Buffer Size" to more accurately reflect the error condition.
- [+] test(stream): update test case for unexpected chunk size error
- [+] The test case for decrypting with an unexpected chunk size has been updated to check for the new error message. The test now uses a short buffer size of 1 and compares the returned error message to the expected "XChacha20Poly1305: Unexpected Chunk Buffer Size".