### PR TITLE
Improve [Crypto] [Hybrid Crypto] Error Message Handling

### DIFF
--- a/backend/internal/middleware/authentication/crypto/hybrid/stream/chunk.go
+++ b/backend/internal/middleware/authentication/crypto/hybrid/stream/chunk.go
@@ -217,7 +217,7 @@ func (s *Stream) extractHMACDigest(encryptedChunk []byte, chunkSize uint16) ([]b
 		hmacDigestSize := s.hmac.Size()
 		if len(encryptedChunk) < hmacDigestSize {
 			// TODO: Use math to handle this error differently since it was uncovered in a test and performs low-level operations on I/O primitives.
-			return nil, nil, errors.New("invalid HMAC digest size") // Deep/Unknown Error Location in I/O primitives
+			return nil, nil, errors.New("Hybrid Scheme: invalid HMAC digest size") // Deep/Unknown Error Location in I/O primitives
 		}
 		hmacDigest = encryptedChunk[len(encryptedChunk)-hmacDigestSize:]
 		encryptedChunk = encryptedChunk[:len(encryptedChunk)-hmacDigestSize]
@@ -225,7 +225,7 @@ func (s *Stream) extractHMACDigest(encryptedChunk []byte, chunkSize uint16) ([]b
 		// If HMAC is not enabled, check if the encrypted chunk size matches the expected size
 		if len(encryptedChunk) != int(chunkSize) {
 			// TODO: Use math to handle this error differently since it was uncovered in a test and performs low-level operations on I/O primitives.
-			return nil, nil, errors.New("encrypted chunk size mismatch") // Deep/Unknown Error Location in I/O primitives
+			return nil, nil, errors.New("Hybrid Scheme: encrypted chunk size mismatch") // Deep/Unknown Error Location in I/O primitives
 		}
 	}
 	return hmacDigest, encryptedChunk, nil


### PR DESCRIPTION
- [+] refactor(chunk.go): improve error messages for hybrid stream chunk processing
- [+] Add "Hybrid Scheme: " prefix to error messages for better context
- [+] Update error message for invalid HMAC digest size
- [+] Update error message for encrypted chunk size mismatch

Note: This Unknown Location in I/O