### PR TITLE
Improve [Crypto] [Hybrid Scheme] XChacha20Poly1305 NonceSizeX

### DIFF
--- a/backend/internal/middleware/authentication/crypto/hybrid/stream/stream_test.go
+++ b/backend/internal/middleware/authentication/crypto/hybrid/stream/stream_test.go
@@ -774,8 +774,8 @@ func TestHybridEncryptDecryptStreamHasBeenCompromised(t *testing.T) {
 	// Simulate unauthorized modification of the encrypted data.
 	//
 	// Let's say this Data has been Compromised.
-	// Note: Without HMAC it's starting from 2
-	encryptedData[2] ^= 0xFF // Flip the second byte of the encrypted data.
+	// Note: Without HMAC it's starting from 1 now.
+	encryptedData[1] ^= 0xFF // Flip the first byte of the encrypted data.
 
 	// Decrypt the data.
 	decryptedBuffer := new(bytes.Buffer)


### PR DESCRIPTION
- [+] feat(chunk.go): use larger nonce capacity for XChaCha20-Poly1305 encryption This change follows the recommended technique from the Go documentation to generate a unique nonce and anti-tamper for XChaCha20-Poly1305 encryption. By using a larger capacity for the nonce slice, the output of the nonce along with the cryptographic randomness will always be unique, ensuring better security.

- [+] fix(chunk.go): update XChaCha20-Poly1305 decryption to handle larger nonce The decryption process is updated to handle the larger nonce size used in the encryption. The nonce and encrypted data are now extracted correctly from the input slice before decryption.

- [+] test(stream_test.go): adjust compromised data index in test case The index of the compromised data in the test case is adjusted to account for the change in the encrypted data structure due to the larger nonce size.