### PR TITLE
Improve [Crypto] [Hybrid Scheme] AES CTR

### DIFF
--- a/backend/internal/middleware/authentication/crypto/hybrid/stream/chunk.go
+++ b/backend/internal/middleware/authentication/crypto/hybrid/stream/chunk.go
@@ -36,7 +36,7 @@ func (s *Stream) encryptChunk(chunk []byte) ([]byte, []byte, error) {
 	}
 
 	// Encrypt the chunk using AES-CTR.
-	aesStream := cipher.NewCTR(s.aesBlock, aesNonce)
+	aesStream := s.cipher(aesNonce)
 	aesEncryptedChunk := make([]byte, len(chunk))
 	aesStream.XORKeyStream(aesEncryptedChunk, chunk)
 


### PR DESCRIPTION
- [+] refactor(hybrid/stream): replace direct usage of cipher.NewCTR with a cipher function field

- [+] feat(hybrid/stream): add key length validation in New function for AES and XChaCha20-Poly1305 keys

- [+] test(hybrid/stream): add test cases for invalid and valid key lengths in New function