### PR TITLE
Implement [Crypto] [Hybrid Scheme] nonce capacity calculation logic

### DIFF
--- a/backend/internal/middleware/authentication/crypto/hybrid/stream/nonce.go
+++ b/backend/internal/middleware/authentication/crypto/hybrid/stream/nonce.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// License: BSD 3-Clause License
+
+package stream
+
+// calculateAESNonceCapacity calculates the nonce capacity for AES-CTR based on the overhead.
+// It takes the overhead as input and returns the calculated nonce capacity.
+// The nonce capacity is calculated as the sum of the AES block size and the overhead.
+// If the calculated capacity is less than the AES block size, it is set to the AES block size.
+// Otherwise, an additional capacity percentage is added to the calculated capacity.
+func (s *Stream) calculateAESNonceCapacity(overhead int) int {
+	capacity := s.aesBlock.BlockSize() + overhead
+	if capacity < s.aesBlock.BlockSize() {
+		capacity = s.aesBlock.BlockSize()
+	} else {
+		capacity += int(float64(capacity) * additionalCapacityPercentage)
+	}
+	return capacity
+}
+
+// calculateChachaNonceCapacity calculates the nonce capacity for XChaCha20-Poly1305 based on the nonce size and overhead.
+// It takes the nonce size and overhead as input and returns the calculated nonce capacity.
+// The nonce capacity is calculated as the sum of the nonce size and the overhead.
+// If the calculated capacity is less than the nonce size, it is set to the nonce size.
+// Otherwise, an additional capacity percentage is added to the calculated capacity.
+func (s *Stream) calculateChachaNonceCapacity(nonceSize, overhead int) int {
+	capacity := nonceSize + overhead
+	if capacity < nonceSize {
+		capacity = nonceSize
+	} else {
+		capacity += int(float64(capacity) * additionalCapacityPercentage)
+	}
+	return capacity
+}


### PR DESCRIPTION
- [+] refactor(stream): extract nonce capacity calculation logic into separate functions
- [+] feat(stream): add AESNonceCapacity and ChachaNonceCapacity methods to calculate nonce capacities
- [+] refactor(chunk): use AESNonceCapacity and ChachaNonceCapacity methods for nonce capacity calculation