### PR TITLE
Remove [Crypto] [Hybrid Scheme] Unused Variable

### DIFF
--- a/backend/internal/middleware/authentication/crypto/hybrid/stream/chunk.go
+++ b/backend/internal/middleware/authentication/crypto/hybrid/stream/chunk.go
@@ -73,7 +73,7 @@ func (s *Stream) encryptChunk(chunk []byte) ([]byte, []byte, error) {
 // decryptChunk decrypts a single chunk using XChaCha20-Poly1305 and AES-CTR.
 func (s *Stream) decryptChunk(chachaNonce, chachaEncryptedChunk []byte) ([]byte, error) {
 	// Decrypt the chunk using XChaCha20-Poly1305.
-	_, chachaEncrypted := chachaEncryptedChunk[:s.chacha.NonceSize()], chachaEncryptedChunk[s.chacha.NonceSize():]
+	chachaEncrypted := chachaEncryptedChunk[s.chacha.NonceSize():]
 	aesEncryptedChunk, err := s.chacha.Open(nil, chachaNonce, chachaEncrypted, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- [+] refactor(stream): remove unused variable when decrypting chunk with XChaCha20-Poly1305

Reason: No longger needed