### PR TITLE
Implement [Crypto] [Hybrid Scheme] Customize Nonce Capacity

### DIFF
--- a/backend/internal/middleware/authentication/crypto/hybrid/stream/nonce.go
+++ b/backend/internal/middleware/authentication/crypto/hybrid/stream/nonce.go
@@ -14,7 +14,7 @@ func (s *Stream) calculateAESNonceCapacity(overhead int) int {
 	if capacity < s.aesBlock.BlockSize() {
 		capacity = s.aesBlock.BlockSize()
 	} else {
-		capacity += int(float64(capacity) * additionalCapacityPercentage)
+		capacity += int(float64(capacity) * s.customizeNonce.AESNonceCapacity)
 	}
 	return capacity
 }
@@ -29,7 +29,7 @@ func (s *Stream) calculateChachaNonceCapacity(nonceSize, overhead int) int {
 	if capacity < nonceSize {
 		capacity = nonceSize
 	} else {
-		capacity += int(float64(capacity) * additionalCapacityPercentage)
+		capacity += int(float64(capacity) * s.customizeNonce.ChachaNonceCapacity)
 	}
 	return capacity
 }

--- a/backend/internal/middleware/authentication/crypto/hybrid/stream/stream_test.go
+++ b/backend/internal/middleware/authentication/crypto/hybrid/stream/stream_test.go
@@ -1151,3 +1151,45 @@ func TestNew_ValidKeyLength(t *testing.T) {
 		})
 	}
 }
+
+func TestEncryptWithCustomizeNonceCapacity(t *testing.T) {
+	aesKey := make([]byte, 32)
+	chachaKey := make([]byte, 32)
+
+	stream, err := stream.New(aesKey, chachaKey)
+	if err != nil {
+		t.Fatalf("Failed to create stream: %v", err)
+	}
+
+	stream.CustomizeNonceCapacity(0.50, 0.50)
+
+	plaintext := []byte("Hello, World! This is a test of the hybrid encryption system With Customize Nonce Capacity.")
+	input := bytes.NewReader(plaintext)
+	output := &bytes.Buffer{}
+
+	err = stream.Encrypt(input, output)
+	if err != nil {
+		t.Fatalf("Encryption failed: %v", err)
+	}
+
+	hexEncoded := hex.EncodeToString(output.Bytes())
+	t.Logf("Encrypted output (hex encoded): %s", hexEncoded)
+
+	// Decrypt the hex-encoded data
+	hexDecoded, err := hex.DecodeString(hexEncoded)
+	if err != nil {
+		t.Fatalf("Failed to decode hex: %v", err)
+	}
+
+	var decryptedOutput strings.Builder
+	err = stream.Decrypt(bytes.NewReader(hexDecoded), &decryptedOutput)
+	if err != nil {
+		t.Fatalf("Decryption failed: %v", err)
+	}
+
+	if decryptedOutput.String() != string(plaintext) {
+		t.Errorf("Decrypted output does not match plaintext")
+	}
+
+	t.Logf("Decrypted output: %s", decryptedOutput.String())
+}


### PR DESCRIPTION
- [+] feat(stream): add CustomizeNonceCapacity method to customize nonce capacity

Note: The CustomizeNonceCapacity method allows customizing the nonce capacity for AES-CTR and XChaCha20-Poly1305 in the Stream struct. It introduces a new CustomizeCapacityNonce struct to store the customized nonce capacities. The default value for both AESNonceCapacity and ChachaNonceCapacity is set to 0.05 (5% additional capacity). The calculateAESNonceCapacity and calculateChachaNonceCapacity methods are updated to use the customized nonce capacities. A new test case TestEncryptWithCustomizeNonceCapacity is added to verify the functionality of the CustomizeNonceCapacity method.