### PR TITLE
Refactor [Crypto] [Hybrid Scheme] Error Messages

### DIFF
--- a/backend/internal/middleware/authentication/crypto/hybrid/stream/chunk.go
+++ b/backend/internal/middleware/authentication/crypto/hybrid/stream/chunk.go
@@ -221,7 +221,7 @@ func (s *Stream) readChunkMetadata(input io.Reader) (uint16, []byte, error) {
 	chunkSizeBuf := make([]byte, minChunkBuf)
 	if _, err := io.ReadAtLeast(input, chunkSizeBuf, minChunkBuf); err != nil {
 		if err == io.ErrUnexpectedEOF {
-			return 0, nil, errors.New("XChacha20Poly1305: Unexpected Chunk Buffer Size")
+			return 0, nil, errors.New("XChaCha20-Poly1305: Unexpected Chunk Buffer Size")
 		}
 		return 0, nil, err
 	}
@@ -230,7 +230,7 @@ func (s *Stream) readChunkMetadata(input io.Reader) (uint16, []byte, error) {
 	chachaNonce := make([]byte, chacha20poly1305.NonceSizeX)
 	if _, err := io.ReadAtLeast(input, chachaNonce, chacha20poly1305.NonceSizeX); err != nil {
 		if err == io.ErrUnexpectedEOF {
-			return 0, nil, errors.New("XChacha20Poly1305: Unexpected NonceSizeX")
+			return 0, nil, errors.New("XChaCha20-Poly1305: Unexpected NonceSizeX")
 		}
 		return 0, nil, err
 	}
@@ -244,9 +244,9 @@ func (s *Stream) readEncryptedChunk(input io.Reader, chunkSize uint16) ([]byte, 
 	if _, err := io.ReadFull(input, encryptedChunk); err != nil {
 		if err == io.ErrUnexpectedEOF {
 			if len(encryptedChunk) > 0 && s.hmac != nil {
-				return nil, errors.New("XChacha20Poly1305: invalid HMAC digest size") // Middle Error Location in I/O primitives
+				return nil, errors.New("XChaCha20-Poly1305: invalid HMAC digest size") // Middle Error Location in I/O primitives
 			}
-			return nil, errors.New("XChacha20Poly1305: encrypted chunk size mismatch") // Middle Error Location in I/O primitives
+			return nil, errors.New("XChaCha20-Poly1305: encrypted chunk size mismatch") // Middle Error Location in I/O primitives
 		}
 		return nil, err
 	}
@@ -281,7 +281,7 @@ func (s *Stream) verifyHMAC(encryptedChunk, hmacDigest []byte) error {
 	s.hmac.Write(encryptedChunk)
 	expectedHMACDigest := s.hmac.Sum(nil)
 	if subtle.ConstantTimeCompare(hmacDigest, expectedHMACDigest) != 1 {
-		return errors.New("XChacha20Poly1305: HMAC verification failed")
+		return errors.New("XChaCha20-Poly1305: HMAC verification failed")
 	}
 	return nil
 }

--- a/backend/internal/middleware/authentication/crypto/hybrid/stream/stream_test.go
+++ b/backend/internal/middleware/authentication/crypto/hybrid/stream/stream_test.go
@@ -675,8 +675,8 @@ func TestHybridDecryptStreamInvalidHMACDigestSize(t *testing.T) {
 	err = s.Decrypt(bytes.NewBuffer(invalidEncryptedData), decryptedBuffer)
 	if err == nil {
 		t.Errorf("Expected decryption error due to invalid HMAC digest size, but got nil.")
-	} else if err.Error() != "XChacha20Poly1305: invalid HMAC digest size" {
-		t.Errorf("Expected error message 'XChacha20Poly1305: invalid HMAC digest size', but got: %v", err)
+	} else if err.Error() != "XChaCha20-Poly1305: invalid HMAC digest size" {
+		t.Errorf("Expected error message 'XChaCha20-Poly1305: invalid HMAC digest size', but got: %v", err)
 	} else {
 		t.Logf("Decryption failed as expected: %v", err)
 	}
@@ -725,8 +725,8 @@ func TestHybridDecryptStreamEncryptedChunkSizeMismatch(t *testing.T) {
 	err = s.Decrypt(bytes.NewBuffer(encryptedData), decryptedBuffer)
 	if err == nil {
 		t.Errorf("Expected decryption error due to encrypted chunk size mismatch, but got nil.")
-	} else if err.Error() != "XChacha20Poly1305: encrypted chunk size mismatch" {
-		t.Errorf("Expected error message 'XChacha20Poly1305: encrypted chunk size mismatch', but got: %v", err)
+	} else if err.Error() != "XChaCha20-Poly1305: encrypted chunk size mismatch" {
+		t.Errorf("Expected error message 'XChaCha20-Poly1305: encrypted chunk size mismatch', but got: %v", err)
 	} else {
 		t.Logf("Decryption failed as expected: %v", err)
 	}
@@ -909,8 +909,8 @@ func TestDecryptUnexpectedChunk(t *testing.T) {
 	err = s.Decrypt(invalidEncryptedInput, &decryptedOutput)
 	if err == nil {
 		t.Errorf("Expected error due to buffer too short, but got nil.")
-	} else if err.Error() != "XChacha20Poly1305: Unexpected Chunk Buffer Size" {
-		t.Errorf("Expected error message 'XChacha20Poly1305: Unexpected Chunk Buffer Size', but got: %v", err)
+	} else if err.Error() != "XChaCha20-Poly1305: Unexpected Chunk Buffer Size" {
+		t.Errorf("Expected error message 'XChaCha20-Poly1305: Unexpected Chunk Buffer Size', but got: %v", err)
 	} else {
 		t.Logf("Decryption failed as expected: %v", err)
 	}
@@ -971,8 +971,8 @@ func TestHybridDecryptStreamXChaCha20NonceSizeXTooShort(t *testing.T) {
 		err = s.Decrypt(shortBufferReader, decryptedBuffer)
 		if err == nil {
 			t.Errorf("Expected error due to buffer too short, but got nil.")
-		} else if err.Error() != "XChacha20Poly1305: Unexpected NonceSizeX" {
-			t.Errorf("Expected error message 'XChacha20Poly1305: Unexpected NonceSizeX', but got: %v", err)
+		} else if err.Error() != "XChaCha20-Poly1305: Unexpected NonceSizeX" {
+			t.Errorf("Expected error message 'XChaCha20-Poly1305: Unexpected NonceSizeX', but got: %v", err)
 		} else {
 			t.Logf("Decryption failed as expected: %v", err)
 		}
@@ -1127,9 +1127,9 @@ func TestNew_ValidKeyLength(t *testing.T) {
 		aesKey    []byte
 		chachaKey []byte
 	}{
-		{"AES-CTR-128 and XChacha20Poly1305", make([]byte, 16), make([]byte, 32)},
-		{"AES-CTR-192 and XChacha20Poly1305", make([]byte, 24), make([]byte, 32)},
-		{"AES-CTR-256 and XChacha20Poly1305", make([]byte, 32), make([]byte, 32)},
+		{"AES-CTR-128 and XChaCha20-Poly1305", make([]byte, 16), make([]byte, 32)},
+		{"AES-CTR-192 and XChaCha20-Poly1305", make([]byte, 24), make([]byte, 32)},
+		{"AES-CTR-256 and XChaCha20-Poly1305", make([]byte, 32), make([]byte, 32)},
 	}
 
 	for _, tc := range validKeys {


### PR DESCRIPTION
- [+] refactor(chunk.go): replace "XChacha20Poly1305" with "XChaCha20-Poly1305" in error messages
- [+] refactor(stream_test.go): replace "XChacha20Poly1305" with "XChaCha20-Poly1305" in test case names and error messages