### PR TITLE
Docs [TODO] [Crypto] [Hybrid Scheme] Update Comments

### DIFF
--- a/backend/internal/server/boringtls.go
+++ b/backend/internal/server/boringtls.go
@@ -87,6 +87,9 @@ type streamListener struct {
 }
 
 // NewStreamConn creates a new streamConn instance by wrapping a TLS connection and a Stream.
+//
+// Note: This is suitable due to TLS 1.3's improved handling of protocols (e.g., keys, handshake) compared to TLS 1.2, which is more complex and less efficient.
+// However, this is not yet finished as Go 1.23 has not been released.
 func NewStreamConn(tlsConn *tls.Conn, stream *stream.Stream) net.Conn {
 	return &streamConn{
 		Conn:   tlsConn,


### PR DESCRIPTION
- [+] docs(boringtls.go): add note about suitability of TLS 1.3 for streamConn
- [+] docs(boringtls.go): mention that implementation is not yet finished due to Go 1.23 not being released