### PR TITLE
Docs [Crypto] [Hybrid Scheme] [Boring TLS] Update Note

### DIFF
--- a/backend/internal/server/boringtls.go
+++ b/backend/internal/server/boringtls.go
@@ -88,8 +88,9 @@ type streamListener struct {
 
 // NewStreamConn creates a new streamConn instance by wrapping a TLS connection and a Stream.
 //
-// Note: This is suitable due to TLS 1.3's improved handling of protocols (e.g., keys, handshake) compared to TLS 1.2, which is more complex and less efficient.
-// However, this is not yet finished as Go 1.23 has not been released.
+// Note: This is suitable due to TLS 1.3's improved handling of protocols (e.g., keys, handshake)
+// compared to TLS 1.2, which is more complex and less efficient. It's no wonder TLS 1.2 is more susceptible to DoS attacks.
+// However, this implementation is not yet complete as Go 1.23 has not been released.
 func NewStreamConn(tlsConn *tls.Conn, stream *stream.Stream) net.Conn {
 	return &streamConn{
 		Conn:   tlsConn,


### PR DESCRIPTION
- [+] docs(boringtls): add note about TLS 1.2 being more susceptible to DoS attacks compared to TLS 1.3