### PR TITLE
Improve [Crypto] Ancient bcrypt

### DIFF
--- a/backend/internal/database/mysql_redis.go
+++ b/backend/internal/database/mysql_redis.go
@@ -259,7 +259,13 @@ func New() Service {
 		// Initialize bcrypt
 		// Note: This operation should be inexpensive as it uses a pointer,
 		// and the garbage collector will be happy handling memory efficiently. 🤪
-		bchash := bcrypt.New()
+		bchash, err := bcrypt.New()
+
+		if err != nil {
+			// This will not be a connection error, but a DSN parse error or
+			// another initialization error.
+			log.LogFatal("Failed to initialize bcrypt:", err)
+		}
 
 		// Create the service instance
 		dbInstance = &service{

--- a/backend/internal/database/mysql_redis.go
+++ b/backend/internal/database/mysql_redis.go
@@ -262,7 +262,7 @@ func New() Service {
 		bchash, err := bcrypt.New()
 
 		if err != nil {
-			// This will not be a connection error, but a DSN parse error or
+			// This will not be a connection error, but a Cost error or
 			// another initialization error.
 			log.LogFatal("Failed to initialize bcrypt:", err)
 		}

--- a/backend/internal/middleware/authentication/crypto/bcrypt/bcrypt.go
+++ b/backend/internal/middleware/authentication/crypto/bcrypt/bcrypt.go
@@ -4,6 +4,12 @@
 
 package bcrypt
 
+import (
+	"errors"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
 // Service is the interface for the bcrypt password hashing service.
 // It provides methods for password hashing and comparison.
 type Service interface {
@@ -16,20 +22,39 @@ type Service interface {
 }
 
 // Hash is an implementation of the bcrypt password hashing Service interface.
-type Hash struct{}
+type Hash struct {
+	cost int
+}
+
+var (
+	// ErrInvalidCost is returned when the provided cost is outside the allowed range.
+	ErrInvalidCost = errors.New("bcrypt: invalid cost")
+)
 
 // New creates a new instance of the bcrypt password hashing service.
-func New() Service {
-	return &Hash{}
+// If the cost is not provided or is outside the allowed range (MinCost to MaxCost),
+// it will return an error.
+func New(cost ...int) (Service, error) {
+	h := &Hash{}
+	if len(cost) > 0 {
+		h.cost = cost[0]
+	}
+	if h.cost < bcrypt.MinCost {
+		h.cost = bcrypt.DefaultCost
+	}
+	if h.cost > bcrypt.MaxCost {
+		return nil, ErrInvalidCost
+	}
+	return h, nil
 }
 
 // HashPassword takes a plaintext password and returns the bcrypt hash of the password.
-func (s *Hash) HashPassword(password string) (string, error) {
-	return HashPassword(password)
+func (b *Hash) HashPassword(password string) (string, error) {
+	return b.hashPassword(password)
 }
 
 // ComparePassword compares a plaintext password with the stored bcrypt hash.
 // It returns true if the password matches the hash, false otherwise.
-func (s *Hash) ComparePassword(password, hash string) bool {
-	return ComparePassword(password, hash)
+func (b *Hash) ComparePassword(password, hash string) bool {
+	return b.comparePassword(password, hash)
 }

--- a/backend/internal/middleware/authentication/crypto/bcrypt/bcrypt_test.go
+++ b/backend/internal/middleware/authentication/crypto/bcrypt/bcrypt_test.go
@@ -10,39 +10,11 @@ import (
 	"h0llyw00dz-template/backend/internal/middleware/authentication/crypto/bcrypt"
 )
 
-func TestHashPassword(t *testing.T) {
-	password := "password123"
-
-	hashedPassword, err := bcrypt.HashPassword(password)
-	if err != nil {
-		t.Fatalf("Failed to hash password: %v", err)
-	}
-
-	if len(hashedPassword) == 0 {
-		t.Error("Hashed password is empty")
-	}
-}
-
-func TestComparePassword(t *testing.T) {
-	password := "password123"
-	incorrectPassword := "incorrect"
-
-	hashedPassword, err := bcrypt.HashPassword(password)
-	if err != nil {
-		t.Fatalf("Failed to hash password: %v", err)
-	}
-
-	if !bcrypt.ComparePassword(password, hashedPassword) {
-		t.Error("ComparePassword returned false for correct password")
-	}
-
-	if bcrypt.ComparePassword(incorrectPassword, hashedPassword) {
-		t.Error("ComparePassword returned true for incorrect password")
-	}
-}
-
 func TestBcryptService_HashPassword(t *testing.T) {
-	bcryptService := bcrypt.New()
+	bcryptService, err := bcrypt.New()
+	if err != nil {
+		t.Fatalf("Failed to create bcrypt service: %v", err)
+	}
 	password := "password123"
 
 	hashedPassword, err := bcryptService.HashPassword(password)
@@ -56,7 +28,10 @@ func TestBcryptService_HashPassword(t *testing.T) {
 }
 
 func TestBcryptService_ComparePassword(t *testing.T) {
-	bcryptService := bcrypt.New()
+	bcryptService, err := bcrypt.New()
+	if err != nil {
+		t.Fatalf("Failed to create bcrypt service: %v", err)
+	}
 	password := "password123"
 	incorrectPassword := "incorrect"
 
@@ -71,5 +46,54 @@ func TestBcryptService_ComparePassword(t *testing.T) {
 
 	if bcryptService.ComparePassword(incorrectPassword, hashedPassword) {
 		t.Error("ComparePassword returned true for incorrect password")
+	}
+}
+
+func TestBcryptService_HashPasswordWithCustomCost(t *testing.T) {
+	bcryptService, err := bcrypt.New(12)
+	if err != nil {
+		t.Fatalf("Failed to create bcrypt service: %v", err)
+	}
+	password := "password123"
+
+	hashedPassword, err := bcryptService.HashPassword(password)
+	if err != nil {
+		t.Fatalf("Failed to hash password: %v", err)
+	}
+
+	if len(hashedPassword) == 0 {
+		t.Error("Hashed password is empty")
+	}
+}
+
+func TestBcryptService_ComparePasswordWithCustomCost(t *testing.T) {
+	bcryptService, err := bcrypt.New(12)
+	if err != nil {
+		t.Fatalf("Failed to create bcrypt service: %v", err)
+	}
+	password := "password123"
+	incorrectPassword := "incorrect"
+
+	hashedPassword, err := bcryptService.HashPassword(password)
+	if err != nil {
+		t.Fatalf("Failed to hash password: %v", err)
+	}
+
+	if !bcryptService.ComparePassword(password, hashedPassword) {
+		t.Error("ComparePassword returned false for correct password")
+	}
+
+	if bcryptService.ComparePassword(incorrectPassword, hashedPassword) {
+		t.Error("ComparePassword returned true for incorrect password")
+	}
+}
+
+func TestBcryptService_InvalidCost(t *testing.T) {
+	_, err := bcrypt.New(32)
+	if err == nil {
+		t.Error("Expected an error for invalid cost, but got nil")
+	}
+	if err != bcrypt.ErrInvalidCost {
+		t.Errorf("Expected ErrInvalidCost, but got: %v", err)
 	}
 }

--- a/backend/internal/middleware/authentication/crypto/bcrypt/compare_password.go
+++ b/backend/internal/middleware/authentication/crypto/bcrypt/compare_password.go
@@ -10,7 +10,7 @@ import (
 
 // ComparePassword compares a plaintext password with the stored bcrypt hash.
 // It returns true if the password matches the hash, false otherwise.
-func ComparePassword(password, hash string) bool {
+func (b *Hash) comparePassword(password, hash string) bool {
 	err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
 	return err == nil
 }

--- a/backend/internal/middleware/authentication/crypto/bcrypt/hash_password.go
+++ b/backend/internal/middleware/authentication/crypto/bcrypt/hash_password.go
@@ -6,8 +6,8 @@ package bcrypt
 
 import "golang.org/x/crypto/bcrypt"
 
-// HashPassword takes a plaintext password and returns the bcrypt hash of the password.
-func HashPassword(password string) (string, error) {
+// hashPassword takes a plaintext password and returns the bcrypt hash of the password.
+func (b *Hash) hashPassword(password string) (string, error) {
 	// Generate a salt with a default cost of 10
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
 	if err != nil {


### PR DESCRIPTION
- [+] refactor(bcrypt): add cost parameter to bcrypt.New and handle invalid cost
- [+] test(bcrypt): add tests for custom cost and invalid cost scenarios
- [+] refactor(bcrypt): make HashPassword and ComparePassword methods of Hash struct
- [+] refactor(bcrypt): rename package-level HashPassword and ComparePassword to hashPassword and comparePassword
- [+] feat(database): handle error from bcrypt.New in database.New
- [+] test(bcrypt): update tests to use bcrypt service instance