### PR TITLE
Fix [Server] [Boring TLS 1.3] Read Method

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,5 @@ k8s-deployment/
 .env
 # H0llyW00dzZ boring TLS 1.3 cert
 boring-boring-boring.txt
+boring-cert.pem
+boring-key.pem

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ main
 
 # H0llyW00dzZ boring TLS 1.3 cert
 boring-boring-boring.txt
+boring-cert.pem
+boring-key.pem

--- a/backend/internal/server/boringtls_test.go
+++ b/backend/internal/server/boringtls_test.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// License: BSD 3-Clause License
+
+package server_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/tls"
+	"h0llyw00dz-template/backend/internal/middleware/authentication/crypto/hybrid/stream"
+	"h0llyw00dz-template/backend/internal/server"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// Note: This is just a test that demonstrates a working example of using TLS 1.3 along with an additional encryption layer.
+// It is still unfinished. If finished, it would require writing a lot of functions when using a custom cipher for the cipher suite (might be copied from std/dependency injection).
+func TestStreamServer(t *testing.T) {
+	// Generate AES key and ChaCha20 key
+	aesKey := make([]byte, 32)
+	chachaKey := make([]byte, 32)
+	_, err := rand.Read(aesKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = rand.Read(chachaKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a new Stream instance
+	s, err := stream.New(aesKey, chachaKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a new Fiber app
+	app := fiber.New()
+
+	// Define a test route
+	app.Get("/test", func(c *fiber.Ctx) error {
+		return c.SendString("Hello, World!")
+	})
+
+	// Load the self-signed certificate and key
+	cert, err := tls.LoadX509KeyPair("boring-cert.pem", "boring-key.pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a TLS configuration for the server
+	tlsConfig := &tls.Config{
+		MinVersion:               tls.VersionTLS13,
+		PreferServerCipherSuites: true,
+		CipherSuites: []uint16{
+			tls.TLS_CHACHA20_POLY1305_SHA256,
+		},
+		CurvePreferences: []tls.CurveID{
+			tls.X25519,
+			tls.CurveP256,
+		},
+		Certificates: []tls.Certificate{cert},
+	}
+
+	// Create a listener
+	listener, err := net.Listen("tcp", ":8080")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wrap the listener with streamListener
+	streamListener := server.NewStreamListener(listener, tlsConfig, s)
+
+	// Create a channel to receive the server error
+	errChan := make(chan error)
+
+	// Start the server
+	go func() {
+		errChan <- app.Listener(streamListener)
+	}()
+
+	// Wait for the server to start
+	time.Sleep(time.Second)
+
+	// Create a TLS client configuration
+	clientTLSConfig := &tls.Config{
+		MinVersion: tls.VersionTLS13,
+		CipherSuites: []uint16{
+			tls.TLS_CHACHA20_POLY1305_SHA256,
+		},
+		CurvePreferences: []tls.CurveID{
+			tls.X25519,
+			tls.CurveP256,
+		},
+		InsecureSkipVerify: true,
+		ServerName:         "localhost",
+	}
+
+	// Create a TLS connection to the server
+	conn, err := tls.Dial("tcp", "localhost:8080", clientTLSConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	// Create a new Stream instance for the client
+	clientStream, err := stream.New(aesKey, chachaKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Send an encrypted request to the server
+	req := "GET /test HTTP/1.1\r\nHost: localhost:8080\r\n\r\n"
+	encryptedReq := &bytes.Buffer{}
+	err = clientStream.Encrypt(bytes.NewReader([]byte(req)), encryptedReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = conn.Write(encryptedReq.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read the encrypted response from the server
+	var encryptedResp []byte
+	buffer := make([]byte, 1024)
+	for {
+		n, err := conn.Read(buffer)
+		if err != nil {
+			t.Fatal(err)
+		}
+		encryptedResp = append(encryptedResp, buffer[:n]...)
+		if n < len(buffer) {
+			break
+		}
+	}
+
+	// Decrypt the response
+	decryptedResp := &bytes.Buffer{}
+	err = clientStream.Decrypt(bytes.NewReader(encryptedResp), decryptedResp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check the decrypted response
+	expectedHeaders := []string{
+		"HTTP/1.1 200 OK",
+		"Content-Type: text/plain; charset=utf-8",
+		"Content-Length: 13",
+	}
+	expectedBody := "Hello, World!"
+
+	respLines := strings.Split(decryptedResp.String(), "\r\n")
+	for _, header := range expectedHeaders {
+		if !contains(respLines, header) {
+			t.Errorf("missing expected header: %q", header)
+		}
+	}
+
+	if !contains(respLines, expectedBody) {
+		t.Errorf("missing expected body: %q", expectedBody)
+	}
+
+	// Check if the server returned an error
+	select {
+	case err := <-errChan:
+		t.Fatal(err)
+	default:
+	}
+}
+
+func contains(lines []string, target string) bool {
+	for _, line := range lines {
+		if line == target {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
- [+] chore(.dockerignore): add boring-cert.pem and boring-key.pem to .dockerignore
- [+] chore(.gitignore): add boring-cert.pem and boring-key.pem to .gitignore
- [+] fix(boringtls.go): update Read method to correctly decrypt data
- [+] feat(boringtls.go): add NewStreamListener function to create a new streamListener instance
- [+] test(boringtls_test.go): add test for streamServer using TLS 1.3 and additional encryption layer