### PR TITLE
Docs [Crypto] Update Documentation

### DIFF
--- a/backend/internal/middleware/authentication/crypto/hybrid/stream/docs.go
+++ b/backend/internal/middleware/authentication/crypto/hybrid/stream/docs.go
@@ -1,0 +1,23 @@
+// Package stream provides a hybrid encryption scheme that combines AES-CTR and XChaCha20-Poly1305 algorithms
+// for secure encryption and decryption of data streams. It also supports optional HMAC authentication for added
+// integrity and authenticity.
+//
+// Compatibility:
+//
+// It's important to note that the stream package may not be directly compatible with browsers or other non-Go
+// environments. The specific ciphertext format used by this package relies on the implementation details of the
+// AES-CTR and XChaCha20-Poly1305 algorithms in Go, along with custom chunking and HMAC authentication mechanisms.
+//
+// The stream package is primarily designed for internal use within Go applications. It provides a secure and
+// efficient way to encrypt and decrypt data streams, making it suitable for internal or private communication
+// between Go services or components.
+//
+// Recommended Usage:
+//
+// The stream package is recommended for use in internal or private communication scenarios within a Go application
+// or between Go services. It can be used to secure sensitive data transmission, such as:
+//
+// - Communication between microservices in a distributed system
+// - Encryption of data stored in databases or files
+// - Secure transmission of data between different components of a Go application
+package stream

--- a/backend/internal/server/boringtls_test.go
+++ b/backend/internal/server/boringtls_test.go
@@ -1173,6 +1173,10 @@ func TestStreamServerWithCustomTransport(t *testing.T) {
 	// Define a test route
 	app.Get("/test", func(c *fiber.Ctx) error {
 		if c.Secure() {
+			// Note: This works well for automatic encryption/decryption during transport transparently.
+			// However, do not try this on front-end apps such as browsers,
+			// as it may not be compatible due to the specific cipher used and protocols. If it's still a Go application, it is compatible and works well (e.g., keys, handshake).
+			// Even with TLS 1.3, not all browsers will work if used for HTTPS front-end, even on Firefox (in Firefox, it works; however, it only encrypts and is unable to decrypt), due to the cipher.
 			log.LogInfo("Server: Received request")
 			return c.JSON(fiber.Map{
 				"message": "Hello, World! (via TLS)",


### PR DESCRIPTION
- [+] feat(stream): add package documentation for hybrid encryption stream

The package documentation provides an overview of the stream package, including its purpose, compatibility considerations, and recommended usage scenarios for secure encryption and decryption of data streams using a hybrid approach combining AES-CTR and XChaCha20-Poly1305 algorithms.

- [+] test(boringtls): add compatibility note for stream encryption in test

In the TestStreamServerWithCustomTransport test, a note is added to clarify that while the automatic encryption/decryption during transport works well for internal Go applications, it may not be compatible with front-end apps such as browsers due to the specific cipher used. The note also mentions that even with TLS 1.3, not all browsers will work properly if used for HTTPS front-end, with Firefox being able to encrypt but unable to decrypt.