### PR TITLE
Docs [Server] [Boring TLS 1.3] Update Comment

### DIFF
--- a/backend/internal/server/boringtls.go
+++ b/backend/internal/server/boringtls.go
@@ -20,6 +20,10 @@ import (
 type streamConn struct {
 	// Note: This is already connected because [stream.Stream] is the core of cryptographic operations.
 	// It can be used to write/read over the network, for example, to store encrypted data in a database.
+	// Also note that this wrapper is safe, instead of using an unsafe pointer (e.g, https://pkg.go.dev/unsafe). When it binds * into *tls.Conn,
+	// it already binds everything for the client and server. It doesn't need to be modified as it is already stable.
+	// Even if modified, it only copies the standard library and adds the stream encrypter/decrypter.
+	// However, for modifications made by copying, it only works for Go applications.
 	*tls.Conn
 	*stream.Stream
 }


### PR DESCRIPTION
- [+] refactor(boringtls.go): add comments explaining the safety and stability of streamConn struct