### PR TITLE
Refactor Docs [TODO] [Startup Server] Update Comment

### DIFF
--- a/backend/internal/server/startup_async.go
+++ b/backend/internal/server/startup_async.go
@@ -51,8 +51,11 @@ func NewFiberServer(app *fiber.App, appName, monitorPath string) *FiberServer {
 
 // Start runs the Fiber server in a separate goroutine to listen for incoming requests.
 func (s *FiberServer) Start(addr, monitorPath string) {
-	// TODO: Implement environment mode. For example, when the environment is set to "dev" or "local", it will switch to "Listen".
-	// Otherwise, it will force a change from Listen to NewStreamListener (automatically and transparently encrypting and decrypting, similar to Certificate Transparency my Boring TLS Certificate) to use TLS 1.3 protocols.
+	// TODO: Implement environment mode. For example, when the environment is set to "dev" or "local",
+	// it will switch to "Listen (Non HTTPS)". Otherwise, it will force a change from Listen to ListenTLS
+	// for public access that can be accessed by a browser. For the Go application itself (only accessed by the Go application, which is pretty useful for authentication), it will switch
+	// to a combination of Listener and StreamListener (automatically and transparently encrypting and decrypting,
+	// similar to Certificate Transparency my Boring TLS Certificate) to use TLS 1.3 protocols.
 	// For the certificate, if used at the enterprise or government level, it should be issued to the organization named "Boring TLS" hahaha.
 	go func() {
 		log.LogInfof(MsgServerStart, addr)


### PR DESCRIPTION
- [+] refactor(server): add TODO comment for implementing environment-based server configuration

The comment outlines plans to:
Use Listen (non-HTTPS) for "dev" or "local" environments
 - Switch to ListenTLS for public browser access in other environments
 - Use a combination of Listener and StreamListener with automatic encryption/decryption (similar to Certificate Transparency) for the Go application itself, utilizing TLS 1.3
 - Suggests issuing the certificate to an organization named "Boring TLS" for enterprise or government use