### PR TITLE
Improve Comment [Server] [Boring TLS 1.3] clarification wrapper

### DIFF
--- a/backend/internal/server/boringtls.go
+++ b/backend/internal/server/boringtls.go
@@ -20,9 +20,10 @@ import (
 type streamConn struct {
 	// Note: This is already connected because [stream.Stream] is the core of cryptographic operations.
 	// It can be used to write/read over the network, for example, to store encrypted data in a database.
-	// Also note that this wrapper is safe, instead of using an unsafe pointer (e.g, https://pkg.go.dev/unsafe). When it binds * into *tls.Conn,
+	// Also note that this wrapper is safe, instead of using an unsafe pointer (e.g., https://pkg.go.dev/unsafe). When it binds * into *tls.Conn and *stream.Stream,
 	// it already binds everything for the client and server. It doesn't need to be modified as it is already stable.
-	// Even if modified, it only copies the standard library and adds the stream encrypter/decrypter.
+	// Even if modified, it only copies the standard library and adds the stream encrypter/decrypter along with stream.New for the cipher suites.
+	// This design allows the use of another cipher (due to TLS 1.3 being already secure) for experimental purposes (e.g., implementing another cipher) because it is written in Go, which is safe for cryptography.
 	// However, for modifications made by copying, it only works for Go applications.
 	*tls.Conn
 	*stream.Stream


### PR DESCRIPTION
- [+] refactor(boringtls.go): update comments for streamConn struct

 - Add clarification that the streamConn wrapper is safe and does not use unsafe pointers
 - Explain that modifications to streamConn only involve copying the standard library and adding stream encrypter/decrypter along with stream.New for cipher suites
 - Note that the design allows for experimenting with other ciphers due to the safety of Go for cryptography
 - Mention that modifications made by copying only work for Go applications