### PR TITLE
Refactor Test [Boring TLS 1.3] extract buffer

### DIFF
--- a/backend/internal/server/boringtls_test.go
+++ b/backend/internal/server/boringtls_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
+const chunkingConf = 1024
+
 func tlsConfig(cert tls.Certificate) *tls.Config {
 	log.InitializeLogger("Boring TLS 1.3 Testing", "")
 	return &tls.Config{
@@ -157,7 +159,7 @@ func TestStreamServer(t *testing.T) {
 	// Read the encrypted response from the server
 	log.LogInfo("[Packet Netw0rkz] Server: Reading encrypted response")
 	var encryptedResp []byte
-	buffer := make([]byte, 1024)
+	buffer := make([]byte, chunkingConf)
 	for {
 		n, err := conn.Read(buffer)
 		if err != nil {
@@ -316,7 +318,7 @@ func TestStreamServerExplicitHTTPS(t *testing.T) {
 	// Read the encrypted response from the server
 	log.LogInfo("[Packet Netw0rkz] Server: Reading encrypted response")
 	var encryptedResp []byte
-	buffer := make([]byte, 1024)
+	buffer := make([]byte, chunkingConf)
 	for {
 		n, err := conn.Read(buffer)
 		if err != nil {
@@ -544,7 +546,7 @@ func TestStreamServerStupidMiddleman(t *testing.T) {
 	// Read the response from the server
 	log.LogInfo("[Packet Netw0rkz] Server: Reading response")
 	var resp []byte
-	buffer := make([]byte, 1024)
+	buffer := make([]byte, chunkingConf)
 	n, err := conn.Read(buffer)
 	if err != nil {
 		t.Fatal(err)
@@ -659,7 +661,7 @@ func TestStreamServerExplicitHTTPSUnixPacket(t *testing.T) {
 	// Read the encrypted response from the server
 	log.LogInfo("[Packet Netw0rkz] Server: Reading encrypted response")
 	var encryptedResp []byte
-	buffer := make([]byte, 1024)
+	buffer := make([]byte, chunkingConf)
 	for {
 		n, err := conn.Read(buffer)
 		if err != nil {
@@ -773,7 +775,7 @@ func TestStreamConnDeadlines(t *testing.T) {
 		}
 
 		// Read from the connection
-		buffer := make([]byte, 1024)
+		buffer := make([]byte, chunkingConf)
 		_, err = streamConn.Read(buffer)
 		if err != nil {
 			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
@@ -841,7 +843,7 @@ func TestStreamConnDeadlines(t *testing.T) {
 	// Read the encrypted response from the server
 	log.LogInfo("[Packet Netw0rkz] Server: Reading encrypted response")
 
-	buffer := make([]byte, 1024)
+	buffer := make([]byte, chunkingConf)
 	_, err = conn.Read(buffer)
 	if err == nil {
 		t.Fatal("Expected read timeout error")
@@ -936,7 +938,7 @@ func TestStreamConnSetDeadline(t *testing.T) {
 		}
 
 		// Read from the connection
-		buffer := make([]byte, 1024)
+		buffer := make([]byte, chunkingConf)
 		_, err = streamConn.Read(buffer)
 		if err != nil {
 			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
@@ -996,7 +998,7 @@ func TestStreamConnSetDeadline(t *testing.T) {
 
 	// Read the encrypted response from the server
 	log.LogInfo("[Packet Netw0rkz] Server: Reading encrypted response")
-	buffer := make([]byte, 1024)
+	buffer := make([]byte, chunkingConf)
 	_, err = conn.Read(buffer)
 	if err == nil {
 		t.Fatal("Expected overall deadline error")
@@ -1106,7 +1108,7 @@ func TestStreamServerWithoutAdditionalEncrypt(t *testing.T) {
 	// Read the response from the server (it will be automatically decrypted)
 	log.LogInfo("[Packet Netw0rkz] Server: Reading response")
 	var response []byte
-	buffer := make([]byte, 1024)
+	buffer := make([]byte, chunkingConf)
 	n, err := streamConn.Read(buffer)
 	if err != nil {
 		t.Fatal(err)
@@ -1351,7 +1353,7 @@ func TestUnsupportedBrowserRequest(t *testing.T) {
 
 	// Read the response from the server
 	var resp []byte
-	buffer := make([]byte, 1024)
+	buffer := make([]byte, chunkingConf)
 	for {
 		n, err := conn.Read(buffer)
 		if err != nil {


### PR DESCRIPTION
- [+] refactor(boringtls_test.go): extract buffer size into a constant chunkingConf

Note: This easy configuration