### PR TITLE
Implement [Helper Function] "RandTLS"

### DIFF
--- a/backend/internal/server/boringtls_test.go
+++ b/backend/internal/server/boringtls_test.go
@@ -43,6 +43,7 @@ func tlsConfig(cert tls.Certificate) *tls.Config {
 		},
 		Certificates:   []tls.Certificate{cert},
 		GetCertificate: tlsHandler.GetClientInfo,
+		Rand:           server.RandTLS(),
 	}
 }
 
@@ -1576,7 +1577,7 @@ func TestStandardTLS13ProtocolWithCustomTransport(t *testing.T) {
 	tlsServerConfig := tlsConfig(cert)
 
 	// Create a regular TCP listener
-	ln, err := net.Listen(app.Config().Network, ":8088")
+	ln, err := net.Listen(app.Config().Network, ":443")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1625,7 +1626,7 @@ func TestStandardTLS13ProtocolWithCustomTransport(t *testing.T) {
 
 		// Create a request with a body
 		requestBody := []byte(fmt.Sprintf("Request body from client %d", i+1)) // Encrypting transparently...
-		req, err := http.NewRequest("GET", "https://localhost:8088/test", bytes.NewBuffer(requestBody))
+		req, err := http.NewRequest("GET", "https://localhost:443/test", bytes.NewBuffer(requestBody))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/backend/internal/server/helper.go
+++ b/backend/internal/server/helper.go
@@ -6,8 +6,10 @@ package server
 
 import (
 	"bytes"
+	"crypto/rand"
 	"fmt"
 	"h0llyw00dz-template/backend/internal/database"
+	"io"
 
 	"github.com/gofiber/fiber/v2"
 )
@@ -105,4 +107,57 @@ func isBrowserRequest(data []byte) bool {
 	}
 
 	return false
+}
+
+// RandTLS returns a custom [io.Reader] that provides a fixed-size random byte stream.
+// The returned reader generates 32 random bytes each time it is read from.
+// It uses the cryptographic random generator from the [crypto/rand] package to ensure secure randomness.
+//
+// The RandTLS function is suitable for use as the Rand field in [tls.Config] to provide
+// a source of entropy for nonces and RSA blinding. It ensures that the TLS package
+// always receives 32 random bytes when it requests random data.
+//
+// Example usage:
+//
+//	tlsConfig := &tls.Config{
+//		// ...
+//		Rand: handler.RandTLS(),
+//		// ...
+//	}
+//
+// Note: This Helper function is safe for use by multiple goroutines that call it simultaneously.
+func RandTLS() io.Reader {
+	return &fixedReader{
+		size: 32,
+	}
+}
+
+// fixedReader is a custom [io.Reader] implementation that provides a fixed-size random byte stream.
+// It generates random bytes using the cryptographic random generator from the [crypto/rand] package.
+type fixedReader struct {
+	size int
+}
+
+// Read fills the provided byte slice p with random bytes up to the specified size.
+// It returns the number of bytes read (n) and any error encountered.
+//
+// If the length of p is 0, Read returns immediately with n=0 and err=nil.
+//
+// If the length of p is less than the specified size, Read fills the entire buffer p
+// with random bytes and returns the number of bytes read (n) and any error encountered.
+//
+// If the length of p is greater than or equal to the specified size, Read fills the first
+// size bytes of p with random bytes and returns the number of bytes read (n) and any error encountered.
+func (r *fixedReader) Read(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if len(p) < r.size {
+		// If the provided buffer is smaller than the fixed size,
+		// read as much as possible and return the number of bytes read.
+		return rand.Read(p)
+	}
+
+	// Note: If [rand.Read] fails to generate random bytes, it will be handled by the standard library [crypto/tls] package internally, and you don't need to know about it.
+	return rand.Read(p[:r.size])
 }


### PR DESCRIPTION
- [+] test(boringtls): add custom random source for TLS config in tests
- [+] test(boringtls): change test server port from 8088 to 443
- [+] feat(helper): add RandTLS function to provide fixed-size random byte stream for TLS
- [+] feat(helper): implement fixedReader type for generating fixed-size random bytes