### PR TITLE
Docs [Standard TLS 1.3 Protocol] Update Comments

### DIFF
--- a/backend/cmd/server/run.go
+++ b/backend/cmd/server/run.go
@@ -176,7 +176,7 @@ func TLSConfig(cert tls.Certificate, clientCertPool *x509.CertPool) *tls.Config 
 	tlsHandler := &fiber.TLSHandler{}
 	// Note: Go's standard TLS 1.3 implementation does not allow direct configuration of cipher suites.
 	// This means that while one can specify cipher suites in Go code, the implementation will prioritize the use of
-	// AES-based ciphers like aes_128_gcm_sha256 or aes_256_gcm_sha256 (both bad common cipher, not even allowed to use ChaCha20 especially XChaCha20 which more secure),
+	// AES-based ciphers like TLS_AES_128_GCM_SHA256 or TLS_AES_256_GCM_SHA384 (both bad common cipher, not even allowed to use ChaCha20 especially XChaCha20 which more secure),
 	// which may be slower than ChaCha20 which is faster on some platforms.
 	tlsConfig := &tls.Config{
 		MaxVersion: tls.VersionTLS13, // Explicit

--- a/backend/internal/server/boringtls_test.go
+++ b/backend/internal/server/boringtls_test.go
@@ -1600,6 +1600,8 @@ func TestStandardTLS13ProtocolWithCustomTransport(t *testing.T) {
 		{tls.X25519, tls.CurveP384, tls.CurveP521, tls.CurveP256},
 	}
 
+	// Note: This test case yields the same results as Boring TLS 1.3 Protocol. However, the cipher suite prioritizes "TLS_AES_128_GCM_SHA256" (bad common cipherText)
+	// and does not allow or support the use of "TLS_CHACHA20_POLY1305_SHA256", which could potentially improve performance due to its truncated nature.
 	transports := make([]*http.Transport, len(curvePreferences))
 	for i, curves := range curvePreferences {
 		transports[i] = &http.Transport{


### PR DESCRIPTION
- [+] refactor(run.go): update comments on TLS 1.3 cipher suite limitations
- [+] Clarify that Go's standard TLS 1.3 implementation prioritizes AES-based ciphers
- [+] Specify the exact cipher suite names (TLS_AES_128_GCM_SHA256 and TLS_AES_256_GCM_SHA384)
- [+] Note the potential performance benefits of ChaCha20, especially XChaCha20

- [+] test(boringtls_test.go): add comment on TLS 1.3 cipher suite behavior in test case
- [+] Highlight that the test case yields the same results as Boring TLS 1.3 Protocol
- [+] Mention the prioritization of "TLS_AES_128_GCM_SHA256" cipher suite
- [+] Note the lack of support for "TLS_CHACHA20_POLY1305_SHA256" and its potential performance benefits