### PR TITLE
Implement [Server] [TLS 1.3 Protocol] RecordHeaderError

### DIFF
--- a/backend/internal/server/startup_async.go
+++ b/backend/internal/server/startup_async.go
@@ -72,8 +72,15 @@ func (s *FiberServer) Start(addr, monitorPath string, tlsConfig *tls.Config, str
 			}
 			tlsListener := tls.NewListener(ln, tlsConfig)
 			s.app.SetTLSHandler(tlsHandler)
-			if err := s.app.Listener(tlsListener); err != nil {
-				log.LogFatalf(ErrorHTTPListenAndServe, err)
+
+			// Wrap the Fiber app's Listener method to handle the RecordHeaderError
+			if err := s.app.Listener(WrappedListener{tlsListener}); err != nil {
+				if recordHeaderErr, ok := err.(tls.RecordHeaderError); ok {
+					// TODO: Integrate with Prometheus, for monitoring.
+					log.LogErrorf("TLS record header error: %v", recordHeaderErr)
+				} else {
+					log.LogFatalf(ErrorHTTPListenAndServe, err)
+				}
 			}
 		} else {
 			// Note: This branch handles TLS 1.2 scenarios or TLS 1.3 when run as a receiver forwarder (e.g. from nginx (Non Kubernetes), Ingress from nginx if it's running on Kubernetes)

--- a/backend/internal/server/test13_alert_test.go
+++ b/backend/internal/server/test13_alert_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// License: BSD 3-Clause License
+
+package server_test
+
+import (
+	"crypto/tls"
+	"errors"
+	"h0llyw00dz-template/backend/internal/server"
+	"net"
+	"testing"
+)
+
+// mockListener is a mock implementation of net.Listener for testing purposes.
+type mockListener struct {
+	acceptErr error
+}
+
+// Accept returns a mock connection and the configured error.
+func (l *mockListener) Accept() (net.Conn, error) {
+	return nil, l.acceptErr
+}
+
+// Close is a mock implementation of Close method.
+func (l *mockListener) Close() error {
+	return nil
+}
+
+// Addr is a mock implementation of Addr method.
+func (l *mockListener) Addr() net.Addr {
+	return nil
+}
+
+func TestWrappedListener(t *testing.T) {
+	t.Run("RecordHeaderError", func(t *testing.T) {
+		// Create a mock listener that returns a RecordHeaderError
+		recordHeaderErr := tls.RecordHeaderError{Conn: nil, Msg: "record header error"}
+		mockListener := &mockListener{acceptErr: recordHeaderErr}
+
+		// Create a wrapped listener with the mock listener
+		wrappedListener := server.WrappedListener{Listener: mockListener}
+
+		// Call the Accept method on the wrapped listener
+		conn, err := wrappedListener.Accept()
+
+		// Assert that the returned error is the expected RecordHeaderError
+		if !errors.As(err, &tls.RecordHeaderError{}) {
+			t.Errorf("Expected RecordHeaderError, got: %v", err)
+		}
+
+		// Assert that the returned connection is nil
+		if conn != nil {
+			t.Errorf("Expected nil connection, got: %v", conn)
+		}
+
+		// Log the error details
+		t.Logf("RecordHeaderError: %+v", err)
+	})
+
+	t.Run("OtherError", func(t *testing.T) {
+		// Create a mock listener that returns a different error
+		otherErr := errors.New("other error")
+		mockListener := &mockListener{acceptErr: otherErr}
+
+		// Create a wrapped listener with the mock listener
+		wrappedListener := server.WrappedListener{Listener: mockListener}
+
+		// Call the Accept method on the wrapped listener
+		conn, err := wrappedListener.Accept()
+
+		// Assert that the returned error is the expected error
+		if err != otherErr {
+			t.Errorf("Expected other error, got: %v", err)
+		}
+
+		// Assert that the returned connection is nil
+		if conn != nil {
+			t.Errorf("Expected nil connection, got: %v", conn)
+		}
+
+		// Log the error details
+		t.Logf("OtherError: %v", err)
+	})
+}

--- a/backend/internal/server/tls13_alert.go
+++ b/backend/internal/server/tls13_alert.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// License: BSD 3-Clause License
+
+package server
+
+import (
+	"crypto/tls"
+	"net"
+)
+
+// WrappedListener is a custom listener that wraps the TLS listener and handles the RecordHeaderError.
+type WrappedListener struct {
+	net.Listener
+}
+
+// Accept waits for and returns the next connection to the listener.
+func (l WrappedListener) Accept() (net.Conn, error) {
+	conn, err := l.Listener.Accept()
+	if err != nil {
+		if recordHeaderErr, ok := err.(tls.RecordHeaderError); ok {
+			return nil, recordHeaderErr
+		}
+		return nil, err
+	}
+	return conn, nil
+}


### PR DESCRIPTION
- [+] feat(server): handle TLS 1.3 RecordHeaderError gracefully
- [+] Wrap the Fiber app's Listener method with a custom WrappedListener
- [+] Check for tls.RecordHeaderError and log it without fatally exiting
- [+] Add a TODO comment to integrate with Prometheus for monitoring

- [+] test(server): add unit tests for WrappedListener handling of RecordHeaderError
- [+] Create a mock listener that returns a RecordHeaderError for testing
- [+] Assert that the returned error is the expected RecordHeaderError
- [+] Log the error details for debugging purposes
- [+] Test the case when a different error is returned by the mock listener