### PR TITLE
Feat [Initialize Database] curve preferences TLS

### DIFF
--- a/backend/internal/database/setup.go
+++ b/backend/internal/database/setup.go
@@ -89,6 +89,12 @@ func (config *RedisClientConfig) InitializeRedisClient() *redis.Client {
 			// However Go's standard TLS 1.3 implementation is broken because it keeps forcing the use of the AES-GCM cipher suite.
 			MaxVersion: tls.VersionTLS13,
 			MinVersion: tls.VersionTLS13,
+			CurvePreferences: []tls.CurveID{
+				tls.X25519,
+				tls.CurveP256,
+				tls.CurveP384,
+				tls.CurveP521,
+			},
 		},
 		PoolTimeout:           config.PoolTimeout,           // PoolTimeout should already be a time.Duration
 		PoolSize:              config.PoolSize,              // adding back this for default.
@@ -132,6 +138,12 @@ func (config *FiberRedisClientConfig) InitializeRedisStorage() fiber.Storage {
 			// However Go's standard TLS 1.3 implementation is broken because it keeps forcing the use of the AES-GCM cipher suite.
 			MaxVersion: tls.VersionTLS13,
 			MinVersion: tls.VersionTLS13,
+			CurvePreferences: []tls.CurveID{
+				tls.X25519,
+				tls.CurveP256,
+				tls.CurveP384,
+				tls.CurveP521,
+			},
 		},
 		PoolSize: config.PoolSize, // Adjust the pool size as necessary.
 	})


### PR DESCRIPTION
- [+] feat(database): add curve preferences to TLS configuration for Redis clients

Note: The commit adds curve preferences to the TLS configuration for both the standard Redis client and the Fiber Redis storage client. The added curve preferences include X25519, CurveP256, CurveP384, and CurveP521, which provide additional security options for the TLS handshake process.