### PR TITLE
Improve [CT] Allow MakeHTTPRequest Directly

### DIFF
--- a/backend/internal/server/boringtls_cert.go
+++ b/backend/internal/server/boringtls_cert.go
@@ -153,8 +153,13 @@ func (s *FiberServer) SubmitToCTLog(cert *x509.Certificate, privateKey crypto.Pr
 	}
 	req.Header.Set(ContentType, ContentTypeJSON)
 
-	// Send the HTTP request using the helper function
-	resp, err := httpRequestMaker.MakeHTTPRequest(req)
+	// Send the HTTP request using the helper function or MakeHTTPRequest directly
+	var resp *http.Response
+	if httpRequestMaker != nil {
+		resp, err = httpRequestMaker.MakeHTTPRequest(req)
+	} else {
+		resp, err = s.MakeHTTPRequest(req)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to submit certificate to CT log: %v", err)
 	}


### PR DESCRIPTION
- [+] feat(boringtls_cert.go): add support for using MakeHTTPRequest directly in SubmitToCTLog
- [+] test(boringtls_cert_test.go): add test case for successful submission to CT log using MakeHTTPRequest directly