### PR TITLE
Improve Certificate Transparency Versioning

### DIFF
--- a/backend/internal/server/boringtls_cert.go
+++ b/backend/internal/server/boringtls_cert.go
@@ -53,6 +53,20 @@ const (
 	ContentType = fiber.HeaderContentType
 )
 
+const (
+	// CTVersion1 represents version 1 of the Certificate Transparency (CT) protocol.
+	// It is defined using an iota constant, allowing for easy extensibility and readability.
+	CTVersion1 uint8 = iota + 1
+
+	// CTVersion2 represents version 2 of the Certificate Transparency (CT) protocol.
+	// It is automatically assigned the next value in the iota sequence.
+	CTVersion2
+
+	// LatestCTVersion represents the latest version of the Certificate Transparency (CT) protocol.
+	// It should be updated whenever a new version is added.
+	LatestCTVersion = CTVersion2
+)
+
 // SubmitToCTLog submits the given certificate to the specified Certificate Transparency log.
 //
 // The function takes the following parameters:
@@ -200,7 +214,7 @@ type SCTVerifier struct {
 
 // VerifySCT verifies the signed certificate timestamp (SCT).
 func (v *SCTVerifier) VerifySCT() error {
-	if v.Response.SCTVersion != 0 {
+	if v.Response.SCTVersion < CTVersion1 || v.Response.SCTVersion > LatestCTVersion {
 		return fmt.Errorf("unsupported SCT version: %d", v.Response.SCTVersion)
 	}
 

--- a/backend/internal/server/boringtls_cert_test.go
+++ b/backend/internal/server/boringtls_cert_test.go
@@ -158,7 +158,7 @@ func TestSubmitToCTLog(t *testing.T) {
 				}
 
 				sctResponse := server.SCTResponse{
-					SCTVersion: 0,
+					SCTVersion: server.CTVersion1,
 					ID:         "test-ct-log",
 					Timestamp:  timestamp,
 					Extensions: "",
@@ -228,7 +228,7 @@ func TestSubmitToCTLog(t *testing.T) {
 			DoFunc: func(req *http.Request) (*http.Response, error) {
 				// Prepare the mock response with an invalid SCT response
 				invalidSCTResponse := server.SCTResponse{
-					SCTVersion: 1, // Unsupported SCT version
+					SCTVersion: server.CTVersion2 + 1, // Unsupported SCT version
 				}
 				responseBody, _ := sonic.Marshal(invalidSCTResponse)
 				mockResponse := &http.Response{
@@ -251,7 +251,8 @@ func TestSubmitToCTLog(t *testing.T) {
 		if err == nil {
 			t.Error("Expected an error, but got nil")
 		}
-		if err != nil && err.Error() != "unsupported SCT version: 1" {
+		expectedErrorMessage := fmt.Sprintf("unsupported SCT version: %d", server.CTVersion2+1)
+		if err != nil && err.Error() != expectedErrorMessage {
 			t.Errorf("Unexpected error message: %v", err)
 		}
 	})
@@ -285,7 +286,7 @@ func TestSubmitToCTLog(t *testing.T) {
 				}
 
 				sctResponse := server.SCTResponse{
-					SCTVersion: 0,
+					SCTVersion: server.CTVersion1,
 					ID:         "test-ct-log",
 					Timestamp:  timestamp,
 					Extensions: "",
@@ -340,7 +341,7 @@ func TestSubmitToCTLog(t *testing.T) {
 			}
 
 			sctResponse := server.SCTResponse{
-				SCTVersion: 0,
+				SCTVersion: server.CTVersion1,
 				ID:         "test-ct-log",
 				Timestamp:  timestamp,
 				Extensions: "",


### PR DESCRIPTION
- [+] feat(boringtls_cert): add constants for Certificate Transparency (CT) protocol versions
- [+] refactor(boringtls_cert): update SCT version check to use CT version constants
- [+] test(boringtls_cert): update tests to use CT version constants for SCT responses