### PR TITLE
Rename Test Submit CT Log

### DIFF
--- a/backend/internal/server/boringtls_cert_test.go
+++ b/backend/internal/server/boringtls_cert_test.go
@@ -140,8 +140,8 @@ func TestSubmitToCTLog(t *testing.T) {
 		MakeHTTPRequestFunc: fiberServer.MakeHTTPRequest,
 	}
 
-	// Test case 1: Successful submission to CT log
-	t.Run("SuccessfulSubmission", func(t *testing.T) {
+	// Test case 1: Successful submission to CT log with ECDSA key
+	t.Run("SuccessfulSubmissionECDSA", func(t *testing.T) {
 		// Create a mock HTTP client
 		mockHTTPClient := &MockHTTPClient{
 			DoFunc: func(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
- [+] test(boringtls_cert_test.go): rename test case for successful CT log submission to specify ECDSA key