### PR TITLE
Improve [Certificate Transparency] JSON Marshal/Unmarshal

### DIFF
--- a/backend/internal/server/boringtls_cert.go
+++ b/backend/internal/server/boringtls_cert.go
@@ -192,14 +192,17 @@ func (s *FiberServer) SubmitToCTLog(cert *x509.Certificate, privateKey crypto.Pr
 	if err := s.App.Config().JSONDecoder(responseBody, &response); err != nil {
 		return fmt.Errorf("failed to parse response: %v", err)
 	}
-
+	jsonConfig := json{
+		Marshal: s.App.Config().JSONEncoder,
+	}
 	// Verify the signed certificate timestamp (SCT)
 	sctVerifier := &SCTVerifier{
 		Response: response,
 		Hash:     hash,
 		Cert:     cert,
+		json:     jsonConfig,
 	}
-	if err := sctVerifier.VerifySCT(s.App.Config().JSONEncoder); err != nil {
+	if err := sctVerifier.VerifySCT(); err != nil {
 		return err
 	}
 
@@ -211,10 +214,19 @@ type SCTVerifier struct {
 	Response SCTResponse
 	Hash     [32]byte
 	Cert     *x509.Certificate
+	json
+}
+
+// json is a struct that holds the JSON encoding/decoding configuration.
+// It provides a way to customize the JSON encoding/decoding behavior by specifying
+// a custom Marshal/Unmarshal function.
+type json struct {
+	Marshal   func(v any) ([]byte, error)
+	Unmarshal func(data []byte, v any) error
 }
 
 // VerifySCT verifies the signed certificate timestamp (SCT).
-func (v *SCTVerifier) VerifySCT(jsonEncoder func(v any) ([]byte, error)) error {
+func (v *SCTVerifier) VerifySCT() error {
 	// Note: This is a method Go idiom that uses the constant iota sequence.
 	// It is particularly useful in cryptographic operations (e.g., implementing custom ciphers, custom protocols, or any cryptography-related tasks).
 	if v.Response.SCTVersion < CTVersion1 || v.Response.SCTVersion > LatestCTVersion {
@@ -256,7 +268,7 @@ func (v *SCTVerifier) VerifySCT(jsonEncoder func(v any) ([]byte, error)) error {
 		}
 
 		// Encode the TransItem structure using Fiber's JSON encoding configuration
-		transItemBytes, err := jsonEncoder(transItem)
+		transItemBytes, err := v.json.Marshal(transItem)
 		if err != nil {
 			return fmt.Errorf("failed to encode TransItem: %v", err)
 		}

--- a/backend/internal/server/boringtls_cert.go
+++ b/backend/internal/server/boringtls_cert.go
@@ -13,6 +13,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -281,7 +282,7 @@ func (v *SCTVerifier) VerifySCT() error {
 	switch publicKey := v.Cert.PublicKey.(type) {
 	case *ecdsa.PublicKey:
 		if !ecdsa.VerifyASN1(publicKey, data, signature) {
-			return fmt.Errorf("failed to verify ECDSA signature")
+			return errors.New("failed to verify ECDSA signature")
 		}
 	case *rsa.PublicKey:
 		// Hash the data before verifying the RSA signature

--- a/backend/internal/server/boringtls_cert_test.go
+++ b/backend/internal/server/boringtls_cert_test.go
@@ -130,7 +130,12 @@ func TestSubmitToCTLog(t *testing.T) {
 	}
 
 	// Create a test Fiber server
-	app := fiber.New()
+	app := fiber.New(fiber.Config{
+		JSONEncoder:  sonic.Marshal,
+		JSONDecoder:  sonic.Unmarshal,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
+	})
 	fiberServer := &server.FiberServer{
 		App: app,
 	}
@@ -364,7 +369,12 @@ func TestSubmitToCTLog(t *testing.T) {
 		}
 
 		// Create a test Fiber server
-		app := fiber.New()
+		app := fiber.New(fiber.Config{
+			JSONEncoder:  sonic.Marshal,
+			JSONDecoder:  sonic.Unmarshal,
+			ReadTimeout:  5 * time.Second,
+			WriteTimeout: 5 * time.Second,
+		})
 		fiberServer := &server.FiberServer{
 			App: app,
 		}

--- a/backend/internal/server/boringtls_cert_test.go
+++ b/backend/internal/server/boringtls_cert_test.go
@@ -526,4 +526,277 @@ func TestSubmitToCTLog(t *testing.T) {
 		t.Log("Hello Crypto: Certificate submitted to CT log successfully")
 	})
 
+	// Test case 8: Invalid signature decoding
+	t.Run("InvalidSignatureDecoding", func(t *testing.T) {
+		// Generate a self-signed certificate with a valid ECDSA private key
+		cert, privateKey, err := generateSelfSignedCertECDSA()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Create a mock HTTP client
+		mockHTTPClient := &MockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				// Prepare the mock response with an invalid base64-encoded signature
+				sctResponse := server.SCTResponse{
+					SCTVersion: server.CTVersion1,
+					ID:         "test-ct-log",
+					Timestamp:  uint64(time.Now().Unix()),
+					Extensions: "",
+					Signature:  "invalid-base64-signature",
+				}
+				responseBody, _ := sonic.Marshal(sctResponse)
+				mockResponse := &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBuffer(responseBody)),
+				}
+				return mockResponse, nil
+			},
+		}
+
+		// Replace the MakeHTTPRequestFunc with the mock implementation
+		httpRequestMaker.MakeHTTPRequestFunc = func(req *http.Request) (*http.Response, error) {
+			return mockHTTPClient.Do(req)
+		}
+
+		// Call the SubmitToCTLog method with the HTTPRequestMaker and private key
+		err = fiberServer.SubmitToCTLog(cert, privateKey, ctLog, httpRequestMaker)
+
+		// Assert the expectations
+		if err == nil {
+			t.Error("Expected an error, but got nil")
+		}
+		expectedErrorMessage := "failed to decode signature: illegal base64 data at input byte 7"
+		if err != nil && err.Error() != expectedErrorMessage {
+			t.Errorf("Unexpected error message: %v", err)
+		}
+	})
+
+	// Test case 9: failed verify ECDSA signature
+	t.Run("FailedVerifyECDSASignature", func(t *testing.T) {
+		// Generate a self-signed certificate with a valid ECDSA private key
+		cert, privateKey, err := generateSelfSignedCertECDSA()
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Generate a valid ECDSA private key
+		privateKeyx, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatalf("Failed to generate ECDSA private key: %v", err)
+		}
+
+		// Create a mock HTTP client
+		mockHTTPClient := &MockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				// Prepare the mock response with a valid SCT response
+				// Calculate the SHA-256 hash of the certificate
+				hash := sha256.Sum256(cert.Raw)
+
+				// Prepare the mock response with a valid SCT response
+				timestamp := uint64(time.Now().Unix())
+				data := append(hash[:], []byte(fmt.Sprintf("%d", timestamp))...)
+
+				signature, err := ecdsa.SignASN1(rand.Reader, privateKeyx, data)
+				if err != nil {
+					t.Fatalf("Failed to generate signature: %v", err)
+				}
+				sctResponse := server.SCTResponse{
+					SCTVersion: server.CTVersion1,
+					ID:         "test-ct-log",
+					Timestamp:  timestamp,
+					Extensions: "",
+					Signature:  base64.StdEncoding.EncodeToString(signature),
+				}
+				responseBody, _ := sonic.Marshal(sctResponse)
+				mockResponse := &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBuffer(responseBody)),
+				}
+				return mockResponse, nil
+			},
+		}
+
+		// Replace the MakeHTTPRequestFunc with the mock implementation
+		httpRequestMaker.MakeHTTPRequestFunc = func(req *http.Request) (*http.Response, error) {
+			return mockHTTPClient.Do(req)
+		}
+
+		// Call the SubmitToCTLog method with the HTTPRequestMaker and the mock private key
+		err = fiberServer.SubmitToCTLog(cert, privateKey, ctLog, httpRequestMaker)
+
+		// Assert the expectations
+		if err == nil {
+			t.Error("Expected an error, but got nil")
+		}
+		expectedErrorMessage := "failed to verify ECDSA signature"
+		if err != nil && err.Error() != expectedErrorMessage {
+			t.Errorf("Unexpected error message: %v", err)
+		}
+	})
+
+	// Test case 10: failed verify RSA signature
+	t.Run("FailedVerifyRSASignature", func(t *testing.T) {
+		// Generate a self-signed certificate with a valid RSA private key
+		cert, privateKey, err := generateSelfSignedCertRSA()
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Generate a valid ECDSA private key
+		privateKeyx, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatalf("Failed to generate ECDSA private key: %v", err)
+		}
+
+		// Create a mock HTTP client
+		mockHTTPClient := &MockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				// Prepare the mock response with a valid SCT response
+				// Calculate the SHA-256 hash of the certificate
+				hash := sha256.Sum256(cert.Raw)
+
+				// Prepare the mock response with a valid SCT response
+				timestamp := uint64(time.Now().Unix())
+				data := append(hash[:], []byte(fmt.Sprintf("%d", timestamp))...)
+
+				signature, err := ecdsa.SignASN1(rand.Reader, privateKeyx, data)
+				if err != nil {
+					t.Fatalf("Failed to generate signature: %v", err)
+				}
+				sctResponse := server.SCTResponse{
+					SCTVersion: server.CTVersion1,
+					ID:         "test-ct-log",
+					Timestamp:  timestamp,
+					Extensions: "",
+					Signature:  base64.StdEncoding.EncodeToString(signature),
+				}
+				responseBody, _ := sonic.Marshal(sctResponse)
+				mockResponse := &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBuffer(responseBody)),
+				}
+				return mockResponse, nil
+			},
+		}
+
+		// Replace the MakeHTTPRequestFunc with the mock implementation
+		httpRequestMaker.MakeHTTPRequestFunc = func(req *http.Request) (*http.Response, error) {
+			return mockHTTPClient.Do(req)
+		}
+
+		// Call the SubmitToCTLog method with the HTTPRequestMaker and the mock private key
+		err = fiberServer.SubmitToCTLog(cert, privateKey, ctLog, httpRequestMaker)
+
+		// Assert the expectations
+		if err == nil {
+			t.Error("Expected an error, but got nil")
+		}
+		expectedErrorMessage := "failed to verify RSA signature: crypto/rsa: verification error"
+		if err != nil && err.Error() != expectedErrorMessage {
+			t.Errorf("Unexpected error message: %v", err)
+		}
+	})
+
+	// Test case 11: Failed to Encode certificate
+	t.Run("FailedEncodeCertificate", func(t *testing.T) {
+		// Generate a self-signed certificate with an Unexpected Key
+		cert := &x509.Certificate{
+			PublicKey: struct{}{}, // Unexpected Key
+		}
+
+		// Create a mock HTTP client
+		mockHTTPClient := &MockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				// Prepare the mock response with a valid SCT response
+				timestamp := uint64(time.Now().Unix())
+				sctResponse := server.SCTResponse{
+					SCTVersion: server.CTVersion1,
+					ID:         "test-ct-log",
+					Timestamp:  timestamp,
+					Extensions: "",
+					Signature:  base64.StdEncoding.EncodeToString([]byte("dummy-signature")),
+				}
+				responseBody, _ := sonic.Marshal(sctResponse)
+				mockResponse := &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBuffer(responseBody)),
+				}
+				return mockResponse, nil
+			},
+		}
+
+		// Replace the MakeHTTPRequestFunc with the mock implementation
+		httpRequestMaker.MakeHTTPRequestFunc = func(req *http.Request) (*http.Response, error) {
+			return mockHTTPClient.Do(req)
+		}
+
+		// Call the SubmitToCTLog method with the HTTPRequestMaker and a dummy private key
+		err := fiberServer.SubmitToCTLog(cert, struct{}{}, ctLog, httpRequestMaker)
+
+		// Assert the expectations
+		if err == nil {
+			t.Error("Expected an error, but got nil")
+		}
+		expectedErrorMessage := "failed to encode certificate: x509: certificate private key does not implement crypto.Signer"
+		if err != nil && err.Error() != expectedErrorMessage {
+			t.Errorf("Unexpected error message: %v", err)
+		}
+	})
+
+	// Test case 12: Invalid Timestamp
+	t.Run("InvalidTimestamp", func(t *testing.T) {
+		// Generate a self-signed certificate with a valid ECDSA private key
+		cert, privateKey, err := generateSelfSignedCertECDSA()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Create a mock HTTP client
+		mockHTTPClient := &MockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				// Prepare the mock response with a valid SCT response
+				// Calculate the SHA-256 hash of the certificate
+				hash := sha256.Sum256(cert.Raw)
+
+				// Prepare the mock response with a valid SCT response
+				timestamp := uint64(9999)
+				data := append(hash[:], []byte(fmt.Sprintf("%d", timestamp))...)
+
+				signature, err := ecdsa.SignASN1(rand.Reader, privateKey, data)
+				if err != nil {
+					t.Fatalf("Failed to generate signature: %v", err)
+				}
+				sctResponse := server.SCTResponse{
+					SCTVersion: server.CTVersion1,
+					ID:         "test-ct-log",
+					Timestamp:  timestamp,
+					Extensions: "",
+					Signature:  base64.StdEncoding.EncodeToString(signature),
+				}
+				responseBody, _ := sonic.Marshal(sctResponse)
+				mockResponse := &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(bytes.NewBuffer(responseBody)),
+				}
+				return mockResponse, nil
+			},
+		}
+
+		// Replace the MakeHTTPRequestFunc with the mock implementation
+		httpRequestMaker.MakeHTTPRequestFunc = func(req *http.Request) (*http.Response, error) {
+			return mockHTTPClient.Do(req)
+		}
+
+		// Call the SubmitToCTLog method with the HTTPRequestMaker and the mock private key
+		err = fiberServer.SubmitToCTLog(cert, privateKey, ctLog, httpRequestMaker)
+
+		// Assert the expectations
+		if err == nil {
+			t.Error("Expected an error, but got nil")
+		}
+		expectedErrorMessage := "invalid timestamp: 9999"
+		if err != nil && err.Error() != expectedErrorMessage {
+			t.Errorf("Unexpected error message: %v", err)
+		}
+	})
+
 }


### PR DESCRIPTION
- [+] refactor(SCTVerifier): extract JSON encoding/decoding configuration into a separate struct
- [+] refactor(SCTVerifier): pass JSON encoding/decoding configuration to SCTVerifier instead of individual functions
- [+] refactor(VerifySCT): remove jsonEncoder parameter and use the json field from SCTVerifier