### PR TITLE
Improve [Certificate Transparency] TimeStamp

### DIFF
--- a/backend/internal/server/boringtls_cert.go
+++ b/backend/internal/server/boringtls_cert.go
@@ -274,7 +274,19 @@ func (v *SCTVerifier) VerifySCT() error {
 // VerifyTimestamp checks if the timestamp in the SCT response is within a valid range.
 func (v *SCTVerifier) VerifyTimestamp() bool {
 	now := time.Now().Unix()
-	return v.Response.Timestamp >= uint64(now-24*60*60) && v.Response.Timestamp <= uint64(now+24*60*60)
+	sctTime := int64(v.Response.Timestamp)
+
+	// Check if the SCT timestamp is within ±24 hours from the current time
+	if sctTime < now-24*60*60 || sctTime > now+24*60*60 {
+		return false
+	}
+
+	// Check if the SCT timestamp is within the validity period of the certificate
+	if sctTime < v.Cert.NotBefore.Unix() || sctTime > v.Cert.NotAfter.Unix() {
+		return false
+	}
+
+	return true
 }
 
 // publicKey returns the public key associated with the given private key.


### PR DESCRIPTION
- [+] refactor(boringtls_cert.go): enhance VerifyTimestamp to check SCT timestamp against certificate validity period
- [+] test(boringtls_cert_test.go): add test case for failed Ed25519 signature verification due to expired certificate
- [+] test(boringtls_cert_test.go): define constants for commonly used time durations in tests
- [+] test(boringtls_cert_test.go): update certificate validity periods in test helper functions
- [+] test(boringtls_cert_test.go): add helper function to generate self-signed Ed25519 certificate with expired validity
- [+] refactor(boringtls_cert_test.go): rename transItem to transMissionItem for clarity