### PR TITLE
Enhance BSD 3-Clause License Name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 BSD 3-Clause License
 -----------
 
-Copyright (c) 2024, H0llyW00dzZ
+Copyright (c) 2024, H0llyW00dzZ / H0llyW00dz
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Reason: It's not typo, it had 2 name