### PR TITLE
Enhance KeyAuth + Session Middleware Logic Cache

### DIFF
--- a/backend/internal/middleware/authentication/helper/constant.go
+++ b/backend/internal/middleware/authentication/helper/constant.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// By accessing or using this software, you agree to be bound by the terms
+// of the License Agreement, which you can find at LICENSE files.
+
+package helper
+
+import "time"
+
+// CacheExpiredTTL is the time-to-live (TTL) duration for expired items in the cache.
+// It determines how long an expired item should remain in the cache before being evicted.
+// In this case, expired items will be kept in the cache for 5 minutes.
+const (
+	CacheExpiredTTL = 5 * time.Minute
+)
+
+// APIKeyStatus represents the status of an API key.
+type APIKeyStatus int
+
+const (
+	// APIKeyUnknown represents an unknown API key status.
+	APIKeyUnknown APIKeyStatus = iota
+
+	// APIKeyActive represents an active API key status.
+	APIKeyActive
+
+	// APIKeyExpired represents an expired API key status.
+	APIKeyExpired
+)
+
+// String returns the string representation of the APIKeyStatus.
+func (s APIKeyStatus) String() string {
+	switch s {
+	case APIKeyActive:
+		return "active"
+	case APIKeyExpired:
+		return "expired"
+	default:
+		return "unknown"
+	}
+}

--- a/backend/internal/middleware/authentication/helper/keyauth.go
+++ b/backend/internal/middleware/authentication/helper/keyauth.go
@@ -16,7 +16,10 @@ func GetAPIKeyStatusFromCache(db database.ServiceAuth, key string) (APIKeyStatus
 	cachedStatus, err := db.FiberStorage().Get(key)
 	if err != nil {
 		log.LogErrorf("Failed to get API key status from cache: %v", err)
-		return APIKeyExpired, err
+		// Returning APIKeyUnknown is better than returning APIKeyExpired.
+		// If the key is not found in the cache, it will return APIKeyUnknown without an error.
+		// Otherwise, it will return APIKeyUnknown with an error if an error occurs.
+		return APIKeyUnknown, err
 	}
 	status := string(cachedStatus)
 	switch status {

--- a/backend/internal/middleware/authentication/helper/keyauth.go
+++ b/backend/internal/middleware/authentication/helper/keyauth.go
@@ -12,18 +12,26 @@ import (
 )
 
 // GetAPIKeyStatusFromCache retrieves the API key status from the Redis cache.
-func GetAPIKeyStatusFromCache(db database.ServiceAuth, key string) (string, error) {
+func GetAPIKeyStatusFromCache(db database.ServiceAuth, key string) (APIKeyStatus, error) {
 	cachedStatus, err := db.FiberStorage().Get(key)
 	if err != nil {
 		log.LogErrorf("Failed to get API key status from cache: %v", err)
-		return "", err
+		return APIKeyExpired, err
 	}
-	return string(cachedStatus), nil
+	status := string(cachedStatus)
+	switch status {
+	case APIKeyActive.String():
+		return APIKeyActive, nil
+	case APIKeyExpired.String():
+		return APIKeyExpired, nil
+	default:
+		return APIKeyUnknown, nil
+	}
 }
 
 // UpdateCacheWithExpiredStatus updates the Redis cache with the expired status.
 func UpdateCacheWithExpiredStatus(db database.ServiceAuth, key string) {
-	err := db.FiberStorage().Set(key, []byte("expired"), 5*time.Minute)
+	err := db.FiberStorage().Set(key, []byte(APIKeyExpired.String()), CacheExpiredTTL)
 	if err != nil {
 		log.LogErrorf("Failed to update Redis cache for expired API key: %v", err)
 	}
@@ -32,8 +40,7 @@ func UpdateCacheWithExpiredStatus(db database.ServiceAuth, key string) {
 // UpdateCacheWithActiveStatus updates the Redis cache with the active status and expiration time.
 func UpdateCacheWithActiveStatus(db database.ServiceAuth, key string, expirationDate time.Time) {
 	// Note: This should be set 5 minute as minimum, because it will covered by rate limiter.
-	ttl := 5 * time.Minute
-	err := db.FiberStorage().Set(key, []byte("active"), ttl)
+	err := db.FiberStorage().Set(key, []byte(APIKeyActive.String()), CacheExpiredTTL)
 	if err != nil {
 		log.LogErrorf("Failed to update Redis cache for active API key: %v", err)
 	}


### PR DESCRIPTION
- [+] feat(authentication): add APIKeyStatus constants and string representation
- [+] Introduce APIKeyStatus type to represent the status of an API key.
- [+] Define constants for APIKeyUnknown, APIKeyActive, and APIKeyExpired statuses.
- [+] Implement String() method to return the string representation of APIKeyStatus.

- [+] refactor(authentication): update GetAPIKeyStatusFromCache to return APIKeyStatus
- [+] Modify GetAPIKeyStatusFromCache to return APIKeyStatus instead of string.
- [+] Parse the cached status and return the corresponding APIKeyStatus constant.
- [+] Return APIKeyExpired status and error if failed to get status from cache.

- [+] refactor(authentication): use APIKeyStatus constants in cache update functions
- [+] Update UpdateCacheWithExpiredStatus to use APIKeyExpired constant when setting cache value.
- [+] Update UpdateCacheWithActiveStatus to use APIKeyActive constant when setting cache value.
- [+] Replace hardcoded TTL value with CacheExpiredTTL constant in UpdateCacheWithActiveStatus.