### PR TITLE
Enhance [Frontend Stuff] CSP Header Generator

### DIFF
--- a/backend/internal/middleware/csp/new.go
+++ b/backend/internal/middleware/csp/new.go
@@ -6,8 +6,6 @@
 package csp
 
 import (
-	"fmt"
-
 	log "h0llyw00dz-template/backend/internal/logger"
 
 	"github.com/gofiber/fiber/v2"
@@ -49,12 +47,16 @@ func New(config ...Config) fiber.Handler {
 		// Set the randomness in the context using the configured context key
 		c.Locals(cfg.ContextKey, randomness)
 
+		// Create a map to store custom values for the CSP header
+		customValues := make(map[string]string)
+
 		// Set the CSP header
 		//
 		// Important: Since this CSP header uses a direct digest (using SHA256) without base64 encoding plus immutable. which is idiomatic way.
 		// When using base64 encoding, consider storing the base64 encoded in c.Locals first or somewhere (e.g, database). Avoid fetching the value from
 		// the header and then putting it in the render or direct in the render, as the format will be different due to sanitization.
-		c.Set("Content-Security-Policy", fmt.Sprintf("script-src 'nonce-%s'", randomness))
+		cspValue := cfg.CSPValueGenerator(randomness, customValues)
+		c.Set("Content-Security-Policy", cspValue)
 
 		// Continue to the next middleware/route handler
 		return c.Next()

--- a/backend/internal/middleware/helper.go
+++ b/backend/internal/middleware/helper.go
@@ -1071,3 +1071,12 @@ func WithRandomnessGenerator(customRand func(string) string) func(*csp.Config) {
 		config.RandomnessGenerator = customRand
 	}
 }
+
+// WithCSPValueGenerator is an option function for NewCSPHeaderGenerator that sets the Content-Security-Policy Value generator function.
+func WithCSPValueGenerator(cspvalue func(string, map[string]string) string) func(*csp.Config) {
+	return func(config *csp.Config) {
+		config.CSPValueGenerator = func(randomness string, customValues map[string]string) string {
+			return cspvalue(randomness, customValues)
+		}
+	}
+}


### PR DESCRIPTION
- [+] feat(csp): add CSPValueGenerator function to customize CSP header value
- [+] Introduce CSPValueGenerator field in Config struct to allow customization of CSP header value
- [+] Implement defaultCSPValueGenerator function to generate default CSP header value
- [+] Update New function to use CSPValueGenerator for setting CSP header value
- [+] Add WithCSPValueGenerator option function to set custom CSPValueGenerator

- [+] test(csp): update tests to cover custom CSPValueGenerator functionality
- [+] Modify TestCSPMiddleware to include test case with custom CSPValueGenerator
- [+] Update assertions to match expected CSP header values

- [+] refactor(csp): change ContextKey field type from string to any in Config struct
- [+] docs(csp): update comments and documentation for CSPValueGenerator and related changes