### PR TITLE
Enhance TLS Configuration for establishing secure connections database

### DIFF
--- a/backend/internal/database/mysql_redis.go
+++ b/backend/internal/database/mysql_redis.go
@@ -176,7 +176,8 @@ var (
 	redisPoolTimeout     = os.Getenv(env.RDBPOOLTIMEOUT)
 	redisConnMaxIdleTime = os.Getenv(env.RDBMAXCONNLIFEIDLE)
 	redisConnMaxLifetime = os.Getenv(env.RDBMAXCONNLIFETIME)
-	tlsCAs               = os.Getenv(env.EXTRACERTTLS)
+	mysqltlsCAs          = os.Getenv(env.MYSQLCERTTLS)
+	redistlsCAs          = os.Getenv(env.REDISCERTTLS)
 	dbInstance           *service
 )
 

--- a/backend/internal/database/tls.go
+++ b/backend/internal/database/tls.go
@@ -15,7 +15,7 @@ import (
 //
 // Note: It is now extracted into two functions for CA certificates because other databases (e.g., Redis) might have a different issuer even if the root CA is the same.
 // The reason for extracting it into two functions is that it makes it easier to set up in a load-balancing cloud environment.
-// It is also recommended to use CA chains instead of only the root CA.
+// It is also recommended to use CA chains (e.g, Root CA + Subs CA Without Leaf CA) instead of only the root CA.
 func loadMySQLRootCA() (*x509.CertPool, error) {
 	rootCABase64 := mysqltlsCAs
 	if rootCABase64 == "" {
@@ -39,7 +39,7 @@ func loadMySQLRootCA() (*x509.CertPool, error) {
 //
 // Note: It is now extracted into two functions for CA certificates because other databases (e.g., MySQL) might have a different issuer even if the root CA is the same.
 // The reason for extracting it into two functions is that it makes it easier to set up in a load-balancing cloud environment.
-// It is also recommended to use CA chains instead of only the root CA.
+// It is also recommended to use CA chains (e.g, Root CA + Subs CA Without Leaf CA) instead of only the root CA.
 func loadRedisRootCA() (*x509.CertPool, error) {
 	rootCABase64 := redistlsCAs
 	if rootCABase64 == "" {

--- a/backend/internal/database/tls.go
+++ b/backend/internal/database/tls.go
@@ -11,11 +11,39 @@ import (
 	"fmt"
 )
 
-// loadRootCA loads the root CA certificate from the environment variable.
-func loadRootCA() (*x509.CertPool, error) {
-	rootCABase64 := tlsCAs
+// loadMySQLRootCA loads the MySQL root CA certificate from the environment variable.
+//
+// Note: It is now extracted into two functions for CA certificates because other databases (e.g., Redis) might have a different issuer even if the root CA is the same.
+// The reason for extracting it into two functions is that it makes it easier to set up in a load-balancing cloud environment.
+// It is also recommended to use CA chains instead of only the root CA.
+func loadMySQLRootCA() (*x509.CertPool, error) {
+	rootCABase64 := mysqltlsCAs
 	if rootCABase64 == "" {
-		return nil, fmt.Errorf("EXTRA_CERTS_TLS environment variable is not set")
+		return nil, fmt.Errorf("MYSQL_CERTS_TLS environment variable is not set")
+	}
+
+	rootCABytes, err := base64.StdEncoding.DecodeString(rootCABase64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode root CA: %v", err)
+	}
+
+	rootCAs := x509.NewCertPool()
+	if ok := rootCAs.AppendCertsFromPEM(rootCABytes); !ok {
+		return nil, fmt.Errorf("failed to append root CA to cert pool")
+	}
+
+	return rootCAs, nil
+}
+
+// loadRedisRootCA loads the Redis root CA certificate from the environment variable.
+//
+// Note: It is now extracted into two functions for CA certificates because other databases (e.g., MySQL) might have a different issuer even if the root CA is the same.
+// The reason for extracting it into two functions is that it makes it easier to set up in a load-balancing cloud environment.
+// It is also recommended to use CA chains instead of only the root CA.
+func loadRedisRootCA() (*x509.CertPool, error) {
+	rootCABase64 := redistlsCAs
+	if rootCABase64 == "" {
+		return nil, fmt.Errorf("REDIS_CERTS_TLS environment variable is not set")
 	}
 
 	rootCABytes, err := base64.StdEncoding.DecodeString(rootCABase64)

--- a/env/env.go
+++ b/env/env.go
@@ -46,7 +46,9 @@ const (
 // TLS Configuration
 const (
 	// This environment variable is used to specify additional root CA / subs CA certificates that should be trusted by the application.
-	EXTRACERTTLS = "EXTRA_CERTS_TLS" // Base64-encoded root CA / subs CA certificates for establishing secure connections database (required).
+	MYSQLCERTTLS = "MYSQL_CERTS_TLS" // Base64-encoded root CA / subs CA certificates for establishing secure connections MySQL database (required).
+	REDISCERTTLS = "REDIS_CERTS_TLS" // Base64-encoded root CA / subs CA certificates for establishing secure connections Redis database (required).
+
 )
 
 // Site Middleware Configuration (Optional since it boilerplate and must rewrite a "DomainRouter" in RegisterRoutes (see backend/internal/middleware/routes.go))


### PR DESCRIPTION
- [+] refactor(database): separate root CA loading for MySQL and Redis
- [+] Extract root CA loading into separate functions for MySQL and Redis
- [+] Rename `loadRootCA` to `loadMySQLRootCA` and `loadRedisRootCA`
- [+] Update function calls to use the appropriate root CA loading function
- [+] Add comments explaining the reason for separating root CA loading and best practices

- [+] feat(env): add separate environment variables for MySQL and Redis root CAs
- [+] Introduce `MYSQL_CERTS_TLS` and `REDIS_CERTS_TLS` environment variables
- [+] Update error messages to reference the specific environment variable

- [+] docs(database): add comments for mTLS connection and certificate verification best practices
- [+] Include notes on setting the `tls` parameter to `"?tls=required"` for mTLS connections
- [+] Mention the requirement for leaf CA to include IP in SANs when connecting via IP
- [+] Emphasize the importance of proper certificate verification and advise against disabling it