### PR TITLE
Enhance Key Auth + Session Middleware Logic

### DIFF
--- a/backend/internal/middleware/authentication/keyauth/constant.go
+++ b/backend/internal/middleware/authentication/keyauth/constant.go
@@ -5,8 +5,14 @@
 
 package keyauth
 
+import "time"
+
 const (
 	sessionKey    = "session"
 	apiKey        = "api_key"
 	apiKeyExpired = "api_key_expired"
+)
+
+const (
+	defaultExpryContextKey = time.Second * 2
 )


### PR DESCRIPTION
- [+] feat(keyauth): add functions to check and save API key validity in session
- [+] Introduce `isAPIKeyValidInSession` function to check if the API key is valid and not expired in the session
- [+] Implement `saveAPIKeyInSession` function to save the API key and its expiration status in the session
- [+] Add `defaultExpryContextKey` constant for setting the default expiry time for expired API keys in the session

Note: This New Auth System that relies on API Key Unlike JWT, JWK & their group, however it not fully implemented yet