### PR TITLE
Implement [RDB] "SetKeysAtPipeline" for Enhance Network Performance

### DIFF
--- a/backend/internal/database/constant.go
+++ b/backend/internal/database/constant.go
@@ -5,6 +5,8 @@
 
 package database
 
+import "time"
+
 // Error and message constants for database-related operations.
 const (
 	ErrDBDown                    = "db down: %v"
@@ -36,4 +38,8 @@ const (
 	MsgRedisHighIdleConnections  = "Redis has a high number of idle connections"
 	MsgRedisHighPoolUtilization  = "Redis connection pool utilization is high"
 	MsgRedisHighPoolBottleneck   = "CRITICAL: Redis connection pool bottlenecked! Utilization exceeds 100%. Possible misconfiguration!"
+)
+
+const (
+	defaultCtxTimeout = 5 * time.Minute
 )


### PR DESCRIPTION
- [+] feat(database): add SetKeysAtPipeline method to Service interface for efficient bulk key-value setting in Redis
- [+] feat(database): implement SetKeysAtPipeline method to reduce latency by batching commands into a single network request
- [+] refactor(database): extract default context timeout to a constant