### PR TITLE
Refactor Key Auth + Session Logic Middleware

### DIFF
--- a/backend/internal/database/auth.go
+++ b/backend/internal/database/auth.go
@@ -11,7 +11,6 @@ package database
 import (
 	"database/sql"
 	"errors"
-	"time"
 
 	"h0llyw00dz-template/backend/internal/middleware/authentication/crypto/bcrypt"
 
@@ -30,9 +29,6 @@ var (
 type ServiceAuth interface {
 	// FiberStorage returns the [fiber.Storage] interface for fiber storage middleware.
 	FiberStorage() fiber.Storage
-
-	// SetKeysAtPipeline efficiently sets multiple key-value pairs in Redis with a specified TTL (Time To Live) using pipelining.
-	SetKeysAtPipeline(keyValues map[string]any, ttl time.Duration) error
 }
 
 // serviceAuth is a concrete implementation of the ServiceAuth interface.
@@ -58,12 +54,4 @@ func NewServiceAuth(db *sql.DB, fiberStorage fiber.Storage, bcryptService bcrypt
 // API Keys in the auth middleware.
 func (s *serviceAuth) FiberStorage() fiber.Storage {
 	return s.fiberStorage
-}
-
-// SetKeysAtPipeline reduces the latency cost associated with round-trip time (RTT) by batching multiple commands into a single network request.
-// This method is particularly useful for bulk-insert scenarios where performance is critical.
-//
-// Note: On my rack-server machine, it has a 0-ms (backend) and 20-ms (frontend for visitor/client in the SEA region) response time because we are neighbors, so ¯\_(ツ)_/¯
-func (s *serviceAuth) SetKeysAtPipeline(keyValues map[string]any, ttl time.Duration) error {
-	return s.SetKeysAtPipeline(keyValues, ttl)
 }

--- a/backend/internal/middleware/authentication/helper/constant.go
+++ b/backend/internal/middleware/authentication/helper/constant.go
@@ -64,6 +64,9 @@ type APIKeyData struct {
 // It represents a map of key-value pairs used to store session data related to key authentication.
 // The keys are strings, and the values can be of any type (any).
 // This type alias provides a convenient way to work with session data in a flexible manner.
+//
+// Note: This is currently unused because key-auth and session middleware logic are bound to Fiber storage.
+// However, for other cache handlers (without being bound to Fiber storage), this can be useful.
 type KeyAuthSessData map[string]any
 
 // AuthorizationData represents the authorization data of an API key.

--- a/backend/internal/middleware/authentication/helper/keyauth.go
+++ b/backend/internal/middleware/authentication/helper/keyauth.go
@@ -68,12 +68,8 @@ func UpdateCacheWithExpiredStatus(db database.ServiceAuth, identifier, key strin
 		return
 	}
 
-	pipeLine := KeyAuthSessData{
-		cacheKey: jsonData,
-	}
-
 	// Note: This should be set 5 minute as minimum, because it will covered by rate limiter.
-	if err := db.SetKeysAtPipeline(pipeLine, CacheExpiredTTL); err != nil {
+	if err := db.FiberStorage().Set(cacheKey, jsonData, CacheExpiredTTL); err != nil {
 		log.LogErrorf("Failed to update Redis cache for expired API key: %v", err)
 	}
 }
@@ -99,12 +95,8 @@ func UpdateCacheWithActiveStatus(db database.ServiceAuth, identifier, key string
 		return
 	}
 
-	pipeLine := KeyAuthSessData{
-		cacheKey: jsonData,
-	}
-
 	// Note: This should be set 5 minute as minimum, because it will covered by rate limiter.
-	if err := db.SetKeysAtPipeline(pipeLine, CacheExpiredTTL); err != nil {
+	if err := db.FiberStorage().Set(cacheKey, jsonData, CacheExpiredTTL); err != nil {
 		log.LogErrorf("Failed to update Redis cache for active API key: %v", err)
 	}
 }


### PR DESCRIPTION
- [+] refactor(database): remove unused SetKeysAtPipeline method from ServiceAuth interface and implementation
- [+] docs(helper): add note about KeyAuthSessData being currently unused
- [+] refactor(helper): replace usage of SetKeysAtPipeline with FiberStorage().Set in UpdateCacheWithExpiredStatus and UpdateCacheWithActiveStatus