### PR TITLE
Improve [Helper] MIME Type JSON for Error Response

### DIFF
--- a/backend/pkg/restapis/helper/numeric_test.go
+++ b/backend/pkg/restapis/helper/numeric_test.go
@@ -46,6 +46,7 @@ func TestParseNumericalValue(t *testing.T) {
 }
 
 func TestParseInt64Value(t *testing.T) {
+	log.InitializeLogger("Gopher Testing", "unix")
 	tests := []struct {
 		name     string
 		value    string

--- a/backend/pkg/restapis/helper/restapis_error.go
+++ b/backend/pkg/restapis/helper/restapis_error.go
@@ -13,12 +13,21 @@ type ErrorResponse struct {
 	Error string `json:"error"`
 }
 
+const (
+
+	// MimeApplicationProblemJSON represents the MIME type for problem+json (RFC 7807).
+	MimeApplicationProblemJSON = "application/problem+json"
+
+	// MimeApplicationProblemJSONCharsetUTF8 represents the MIME type for problem+json with UTF-8 charset (RFC 7807 Enhancement).
+	MimeApplicationProblemJSONCharsetUTF8 = "application/problem+json; charset=utf-8"
+)
+
 // SendErrorResponse sends an error response with the specified status code and error message.
 func SendErrorResponse(c *fiber.Ctx, statusCode int, errorMessage string) error {
 	return c.Status(statusCode).JSON(ErrorResponse{
 		Code:  statusCode,
 		Error: errorMessage,
-	})
+	}, MimeApplicationProblemJSONCharsetUTF8)
 }
 
 // ErrorHandler is the error handling middleware that runs after other middleware.

--- a/backend/pkg/restapis/helper/restapis_error_test.go
+++ b/backend/pkg/restapis/helper/restapis_error_test.go
@@ -32,6 +32,11 @@ func TestSendErrorResponse_BadRequest(t *testing.T) {
 		t.Errorf("Expected status code %d, got %d", fiber.StatusBadRequest, resp.StatusCode)
 	}
 
+	contentType := resp.Header.Get("Content-Type")
+	if contentType != helper.MimeApplicationProblemJSONCharsetUTF8 {
+		t.Errorf("Expected Content-Type '%s', got '%s'", helper.MimeApplicationProblemJSONCharsetUTF8, contentType)
+	}
+
 	var errorResponse helper.ErrorResponse
 	err = sonic.ConfigDefault.NewDecoder(resp.Body).Decode(&errorResponse)
 	if err != nil {
@@ -63,6 +68,11 @@ func TestSendErrorResponse_Unauthorized(t *testing.T) {
 
 	if resp.StatusCode != fiber.StatusUnauthorized {
 		t.Errorf("Expected status code %d, got %d", fiber.StatusUnauthorized, resp.StatusCode)
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	if contentType != helper.MimeApplicationProblemJSONCharsetUTF8 {
+		t.Errorf("Expected Content-Type '%s', got '%s'", helper.MimeApplicationProblemJSONCharsetUTF8, contentType)
 	}
 
 	var errorResponse helper.ErrorResponse
@@ -98,6 +108,11 @@ func TestSendErrorResponse_Forbidden(t *testing.T) {
 		t.Errorf("Expected status code %d, got %d", fiber.StatusForbidden, resp.StatusCode)
 	}
 
+	contentType := resp.Header.Get("Content-Type")
+	if contentType != helper.MimeApplicationProblemJSONCharsetUTF8 {
+		t.Errorf("Expected Content-Type '%s', got '%s'", helper.MimeApplicationProblemJSONCharsetUTF8, contentType)
+	}
+
 	var errorResponse helper.ErrorResponse
 	err = sonic.ConfigDefault.NewDecoder(resp.Body).Decode(&errorResponse)
 	if err != nil {
@@ -129,6 +144,11 @@ func TestSendErrorResponse_NotFound(t *testing.T) {
 
 	if resp.StatusCode != fiber.StatusNotFound {
 		t.Errorf("Expected status code %d, got %d", fiber.StatusNotFound, resp.StatusCode)
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	if contentType != helper.MimeApplicationProblemJSONCharsetUTF8 {
+		t.Errorf("Expected Content-Type '%s', got '%s'", helper.MimeApplicationProblemJSONCharsetUTF8, contentType)
 	}
 
 	var errorResponse helper.ErrorResponse
@@ -164,6 +184,11 @@ func TestSendErrorResponse_Conflict(t *testing.T) {
 		t.Errorf("Expected status code %d, got %d", fiber.StatusConflict, resp.StatusCode)
 	}
 
+	contentType := resp.Header.Get("Content-Type")
+	if contentType != helper.MimeApplicationProblemJSONCharsetUTF8 {
+		t.Errorf("Expected Content-Type '%s', got '%s'", helper.MimeApplicationProblemJSONCharsetUTF8, contentType)
+	}
+
 	var errorResponse helper.ErrorResponse
 	err = sonic.ConfigDefault.NewDecoder(resp.Body).Decode(&errorResponse)
 	if err != nil {
@@ -195,6 +220,11 @@ func TestSendErrorResponse_BadGateway(t *testing.T) {
 
 	if resp.StatusCode != fiber.StatusBadGateway {
 		t.Errorf("Expected status code %d, got %d", fiber.StatusBadGateway, resp.StatusCode)
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	if contentType != helper.MimeApplicationProblemJSONCharsetUTF8 {
+		t.Errorf("Expected Content-Type '%s', got '%s'", helper.MimeApplicationProblemJSONCharsetUTF8, contentType)
 	}
 
 	var errorResponse helper.ErrorResponse
@@ -230,6 +260,11 @@ func TestSendErrorResponse_InternalServerError(t *testing.T) {
 		t.Errorf("Expected status code %d, got %d", fiber.StatusInternalServerError, resp.StatusCode)
 	}
 
+	contentType := resp.Header.Get("Content-Type")
+	if contentType != helper.MimeApplicationProblemJSONCharsetUTF8 {
+		t.Errorf("Expected Content-Type '%s', got '%s'", helper.MimeApplicationProblemJSONCharsetUTF8, contentType)
+	}
+
 	var errorResponse helper.ErrorResponse
 	err = sonic.ConfigDefault.NewDecoder(resp.Body).Decode(&errorResponse)
 	if err != nil {
@@ -261,6 +296,11 @@ func TestSendErrorResponse_TooManyRequests(t *testing.T) {
 
 	if resp.StatusCode != fiber.StatusTooManyRequests {
 		t.Errorf("Expected status code %d, got %d", fiber.StatusTooManyRequests, resp.StatusCode)
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	if contentType != helper.MimeApplicationProblemJSONCharsetUTF8 {
+		t.Errorf("Expected Content-Type '%s', got '%s'", helper.MimeApplicationProblemJSONCharsetUTF8, contentType)
 	}
 
 	var errorResponse helper.ErrorResponse
@@ -300,6 +340,11 @@ func TestErrorHandler(t *testing.T) {
 
 	if resp.StatusCode != fiber.StatusInternalServerError {
 		t.Errorf("Expected status code %d, got %d", fiber.StatusInternalServerError, resp.StatusCode)
+	}
+
+	contentType := resp.Header.Get("Content-Type")
+	if contentType != helper.MimeApplicationProblemJSONCharsetUTF8 {
+		t.Errorf("Expected Content-Type '%s', got '%s'", helper.MimeApplicationProblemJSONCharsetUTF8, contentType)
 	}
 
 	var errorResponse helper.ErrorResponse


### PR DESCRIPTION
- [+] test(numeric_test.go): initialize logger in TestParseInt64Value
- [+] feat(restapis_error.go): add constants for problem+json MIME types
- [+] feat(restapis_error.go): set Content-Type header to problem+json with UTF-8 charset in SendErrorResponse
- [+] test(restapis_error_test.go): check Content-Type header in error response tests