### PR TITLE
Enable Stream Request Body

### DIFF
--- a/backend/cmd/server/run.go
+++ b/backend/cmd/server/run.go
@@ -77,6 +77,8 @@ func setupFiber(appName string, readTimeout, writeTimeout time.Duration) *fiber.
 		// Note: It's important to set Prefork to false because if it's enabled and running in Kubernetes,
 		// it may get killed by an Out-of-Memory (OOM) error due to a conflict with the Horizontal Pod Autoscaler (HPA).
 		Prefork: false,
+		// Which is suitable for streaming AI Response.
+		StreamRequestBody: true,
 	})
 }
 


### PR DESCRIPTION
- [+] feat(server): enable StreamRequestBody in Fiber app setup
- [+] This allows streaming the request body, which is suitable for streaming AI responses.