### PR TITLE
Enhance [Helper Function] keyidentifier

### DIFF
--- a/backend/internal/middleware/keyidentifier/ecdsa_sign.go
+++ b/backend/internal/middleware/keyidentifier/ecdsa_sign.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// By accessing or using this software, you agree to be bound by the terms
+// of the License Agreement, which you can find at LICENSE files.
+
+package keyidentifier
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"fmt"
+)
+
+// signUUID signs the given UUID using ECDSA and returns the signature in ASN.1 DER format.
+func (k *KeyIdentifier) signUUID(uuid string) ([]byte, error) {
+	// Check if the private key is set in the configuration
+	if k.config.PrivateKey == nil {
+		return nil, fmt.Errorf("private key is not set in the configuration")
+	}
+
+	// Check if the hash function is set in the configuration
+	if k.config.Digest == nil {
+		return nil, fmt.Errorf("hash function is not set in the configuration")
+	}
+
+	// Digest the UUID using the configured hash function
+	h := k.config.Digest()
+	h.Write([]byte(uuid))
+	digest := h.Sum(nil)
+
+	// Sign the Digest using ECDSA and return the signature in ASN.1 DER format
+	signature, err := ecdsa.SignASN1(rand.Reader, k.config.PrivateKey, digest)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign UUID: %v", err)
+	}
+
+	return signature, nil
+}

--- a/backend/internal/middleware/keyidentifier/generate.go
+++ b/backend/internal/middleware/keyidentifier/generate.go
@@ -6,19 +6,28 @@
 package keyidentifier
 
 import (
+	"fmt"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/utils"
 )
 
 // GetKeyFunc generates a unique key for each request and returns a function that retrieves the key from the context.
-//
-// TODO: Implement a Value Mechanism from [fiber.Ctx] for signing/binding a cryptographic technique to the UUID.
 func (k *KeyIdentifier) GetKeyFunc() func(*fiber.Ctx) string {
 	return func(c *fiber.Ctx) string {
 		// Generate a random UUID
-		//
-		// TODO: Do we really need to improve this by using a cryptographic technique similar to how Bitcoin generates addresses?
 		id := utils.UUIDv4()
+
+		// Sign the UUID using ECDSA
+		if k.config.PrivateKey != nil && k.config.SignedContextKey != nil {
+			signature, err := k.signUUID(id)
+			if err != nil {
+				panic(fmt.Errorf("failed to sign UUID: %v", err))
+			}
+
+			// Store the Signature for future use
+			c.Locals(k.config.SignedContextKey, signature)
+		}
 
 		// Set the key in the context
 		key := k.config.Prefix + id

--- a/backend/internal/middleware/keyidentifier/keyidentifier_test.go
+++ b/backend/internal/middleware/keyidentifier/keyidentifier_test.go
@@ -1,0 +1,111 @@
+package keyidentifier_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"h0llyw00dz-template/backend/internal/middleware/keyidentifier"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/gofiber/fiber/v2"
+)
+
+func TestKeyIdentifier(t *testing.T) {
+	// Generate an ECDSA private key
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("Failed to generate ECDSA private key: %v", err)
+	}
+
+	// Get the public key from the private key
+	publicKey := privateKey.Public().(*ecdsa.PublicKey)
+
+	// Create a new instance of KeyIdentifier with the desired configuration
+	const ecdsaUUID = "ecdsa_authorized:"
+	keyIdentifier := keyidentifier.New(keyidentifier.Config{
+		Prefix:           ecdsaUUID,
+		PrivateKey:       privateKey,
+		Digest:           sha256.New,
+		SignedContextKey: "signature",
+	})
+
+	// Create a new Fiber app
+	app := fiber.New()
+
+	// Define a test route handler
+	app.Get("/test", func(c *fiber.Ctx) error {
+		// Get the generated uuid from the context
+		uuid := keyIdentifier.GetKeyFunc()(c)
+		fmt.Println("Session ID Authorized:", uuid)
+
+		// Get the signature from the context
+		signature := c.Locals("signature").([]byte)
+		fmt.Println("Signature:", signature)
+
+		// Send the uuid, signature, and public key in the response
+		return c.JSON(fiber.Map{
+			"uuid":      uuid,
+			"signature": hex.EncodeToString(signature),
+			"publicKey": hex.EncodeToString(elliptic.Marshal(publicKey.Curve, publicKey.X, publicKey.Y)),
+		})
+	})
+
+	// Create a new HTTP request
+	req := httptest.NewRequest("GET", "/test", nil)
+
+	// Perform the request
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("Failed to perform request: %v", err)
+	}
+
+	// Check the response status code
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status code %d, got %d", http.StatusOK, resp.StatusCode)
+	}
+
+	// Parse the response body using sonic
+	var body map[string]string
+	if err := sonic.ConfigDefault.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("Failed to parse response body: %v", err)
+	}
+
+	// Get the uuid, signature, and public key from the response body
+	uuid := body["uuid"]
+	signatureHex := body["signature"]
+	publicKeyHex := body["publicKey"]
+
+	// Decode the signature from hex
+	signature, err := hex.DecodeString(signatureHex)
+	if err != nil {
+		t.Fatalf("Failed to decode signature: %v", err)
+	}
+
+	// Decode the public key from hex
+	publicKeyBytes, err := hex.DecodeString(publicKeyHex)
+	if err != nil {
+		t.Fatalf("Failed to decode public key: %v", err)
+	}
+
+	// Unmarshal the public key
+	x, y := elliptic.Unmarshal(elliptic.P256(), publicKeyBytes)
+	if x == nil {
+		t.Fatal("Invalid public key")
+	}
+	publicKey = &ecdsa.PublicKey{Curve: elliptic.P256(), X: x, Y: y}
+
+	// Verify the signature
+	h := sha256.New()
+	h.Write([]byte(uuid[len(ecdsaUUID):]))
+	expectedDigest := h.Sum(nil)
+
+	if !ecdsa.VerifyASN1(publicKey, expectedDigest, signature) {
+		t.Error("Signature verification failed")
+	}
+}

--- a/backend/internal/middleware/keyidentifier/new.go
+++ b/backend/internal/middleware/keyidentifier/new.go
@@ -5,18 +5,29 @@
 
 package keyidentifier
 
+import (
+	"crypto/ecdsa"
+	"hash"
+)
+
 // Config represents the configuration options for the key identifier.
 //
 // Note: The Prefix here is not actually a key, it's a group-key. For example, "session_id_authorized:<uuid>",
 // where <uuid> is the actual key to get the value. This is because memory storage is unstructured, unlike
 // relational databases that use queries and tables.
 type Config struct {
-	Prefix string
+	Prefix           string
+	PrivateKey       *ecdsa.PrivateKey
+	Digest           func() hash.Hash
+	SignedContextKey any
 }
 
 // ConfigDefault is the default configuration for the key identifier.
 var ConfigDefault = Config{
-	Prefix: "session_id_authorized:",
+	Prefix:           "session_id_authorized:",
+	PrivateKey:       nil,
+	Digest:           nil,
+	SignedContextKey: nil,
 }
 
 // KeyIdentifier represents the key identifier.


### PR DESCRIPTION
- [+] feat(keyidentifier): add support for signing UUID with ECDSA
- [+] implement signUUID method to sign UUID using ECDSA and return signature in ASN.1 DER format
- [+] update GetKeyFunc to sign UUID and store signature in context using SignedContextKey
- [+] add Config fields for PrivateKey, Digest, and SignedContextKey

- [+] test(keyidentifier): add unit test for KeyIdentifier with ECDSA signing
- [+] generate ECDSA key pair for testing
- [+] create KeyIdentifier instance with ECDSA configuration
- [+] test handling of request, response parsing, and signature verification

- [+] docs(keyidentifier): update comments and documentation
- [+] clarify purpose of Prefix in Config
- [+] add TODO comments for future improvements and considerations