### PR TITLE
Improve [Crypto] [KeyIdentifier] Support HSM

### DIFF
--- a/backend/internal/middleware/authentication/crypto/keyidentifier/ecdsa_sign.go
+++ b/backend/internal/middleware/authentication/crypto/keyidentifier/ecdsa_sign.go
@@ -27,7 +27,18 @@ func (k *KeyIdentifier) signUUID(uuid string) ([]byte, error) {
 	digest := h.Sum(nil)
 
 	// Sign the Digest using ECDSA and return the signature in ASN.1 DER format
-	signature, err := ecdsa.SignASN1(k.secureRandom(), k.config.PrivateKey, digest)
+	var signature []byte
+	var err error
+
+	// Note: Test Skipped for HSM
+	if k.config.HSM != nil {
+		// If an HSM is provided, use the Sign method
+		signature, err = k.config.HSM.Sign(k.secureRandom(), digest, nil)
+	} else {
+		// If no HSM is provided, use SignASN1 with the private key
+		signature, err = ecdsa.SignASN1(k.secureRandom(), k.config.PrivateKey, digest)
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign UUID: %v", err)
 	}

--- a/backend/internal/middleware/authentication/crypto/keyidentifier/new.go
+++ b/backend/internal/middleware/authentication/crypto/keyidentifier/new.go
@@ -6,6 +6,7 @@
 package keyidentifier
 
 import (
+	"crypto"
 	"crypto/ecdsa"
 	"hash"
 	"io"
@@ -22,6 +23,7 @@ type Config struct {
 	Digest           func() hash.Hash
 	SignedContextKey any
 	Rand             io.Reader
+	HSM              crypto.Signer
 }
 
 // ConfigDefault is the default configuration for the key identifier.
@@ -31,6 +33,7 @@ var ConfigDefault = Config{
 	Digest:           nil,
 	SignedContextKey: nil,
 	Rand:             nil,
+	HSM:              nil,
 }
 
 // KeyIdentifier represents the key identifier.


### PR DESCRIPTION
- [+] feat(keyidentifier): add support for hardware security module (HSM) signing
Note: The test for HSM signing is currently skipped.