### PR TITLE
Enchance [Key Auth + Session Middleware Logic]

### DIFF
--- a/backend/internal/middleware/authentication/helper/constant.go
+++ b/backend/internal/middleware/authentication/helper/constant.go
@@ -87,7 +87,7 @@ type AuthorizationData struct {
 	AuthTime time.Time `json:"time,omitempty"`
 	// Note: This expiration time is retrieved from the relational database (MySQL).
 	// The performance speed might be somewhat slow (taking an average of 1s response time in the frontend) during the first query due to the relational database (always slow).
-	// However, when it hits Redis and is released into cookies with encryption, the speed can be faster (possibly 0ms ~ 1ms response time).
+	// However, when it hits Redis/Valkey and is released into cookies with encryption, the speed can be faster (possibly 0ms ~ 1ms response time).
 	ExpiredTime time.Time `json:"apikey_expired_time,omitempty"`
 	Signature   any       `json:"signature,omitempty"`
 }

--- a/backend/internal/middleware/authentication/helper/constant.go
+++ b/backend/internal/middleware/authentication/helper/constant.go
@@ -73,20 +73,21 @@ type KeyAuthSessData map[string]any
 // It includes the following fields:
 // 	- AuthTime: The time of the last authorization.
 // 	- ExpiredTime: The expiration time of the API key.
+// 	- Signature: The signature data associated with the API key, which can be of any type (e.g., ECDSA signature that can be used for enhance security purpose or other purpose).
 //
 // Note: Current format, and may subject to changed:
 // {
 // 	"authorization": {
 // 	  "time": "2024-08-01T21:24:28.4352685Z",
-// 	  "apikey_expired_time": "2024-10-26T21:18:17Z"
+// 	  "apikey_expired_time": "2024-10-26T21:18:17Z",
+// 	  "signature": "..."
 // 	}
 // }
-//
-// TODO: Handle Signature ECDSA, might implement as raw byte instead of string for Signature ECDSA.
 type AuthorizationData struct {
 	AuthTime time.Time `json:"time,omitempty"`
 	// Note: This expiration time is retrieved from the relational database (MySQL).
 	// The performance speed might be somewhat slow (taking an average of 1s response time in the frontend) during the first query due to the relational database (always slow).
 	// However, when it hits Redis and is released into cookies with encryption, the speed can be faster (possibly 0ms ~ 1ms response time).
 	ExpiredTime time.Time `json:"apikey_expired_time,omitempty"`
+	Signature   any       `json:"signature,omitempty"`
 }


### PR DESCRIPTION
- [+] feat(authentication): add Signature field to AuthorizationData struct

Note: The commit message indicates that a new field called `Signature` has been added to the `AuthorizationData` struct. This field is of type `any` and is used to store signature data associated with the API key. The signature data can be used for enhanced security purposes or other purposes. The commit also updates the documentation to reflect the addition of the `Signature` field and removes the TODO comment regarding handling ECDSA signatures.