### PR TITLE
Docs [Crypto] [KeyIdentifier] Update Documentation *Important

### DIFF
--- a/backend/internal/middleware/authentication/crypto/keyidentifier/docs.go
+++ b/backend/internal/middleware/authentication/crypto/keyidentifier/docs.go
@@ -7,8 +7,9 @@
 //
 // Compatibility:
 //
-//   - This package is not directly compatible with Fiber middleware that expects a key generator direct value (e.g, Fiber Rate Limiter where the ip it used as key not the value).
+//   - This package is not directly compatible with Fiber middleware that expects a key generator to provide a direct value (e.g., Fiber Rate Limiter where the IP is used as the key, not the value).
 //     It generates keys independently of the [fiber.Ctx] and does not modify the context.
+//     Also note that using a direct value (e.g., IP address, other sensitive) as the key, as in the case of Fiber Rate Limiter, can lead to a security compromise (possibly a new CVE) because it exposes sensitive information in logs/commander panel.
 //
 //   - The key exchange mechanism for ECDSA is not supported (and won't be implemented even though implementing key exchange is easy) because it is not used for external services such as TLS or other external services.
 package keyidentifier


### PR DESCRIPTION
- [+] docs(keyidentifier): clarify compatibility and security considerations
- [+] Clarify that the package is not directly compatible with Fiber middleware expecting a key generator to provide a direct value
- [+] Note that using a direct value (e.g., IP address) as the key can lead to a security compromise by exposing sensitive information in logs/commander panel