### PR TITLE
Reorganize Codebase

### DIFF
--- a/backend/cmd/server/run.go
+++ b/backend/cmd/server/run.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gofiber/fiber/v2"
 
 	log "h0llyw00dz-template/backend/internal/logger"
+	"h0llyw00dz-template/backend/internal/middleware/authentication/crypto/rand"
 	handler "h0llyw00dz-template/backend/internal/server"
 	"h0llyw00dz-template/env"
 )
@@ -212,7 +213,7 @@ func TLSConfig(cert tls.Certificate, leafCA, subCA, rootCA *x509.Certificate, cl
 		GetCertificate: tlsHandler.GetClientInfo,
 		// Note: This safe for multiple goroutines each time it is called, ensuring that each goroutine gets its own independent reader
 		// The fixedReader itself does not maintain any mutable state, making it safe for concurrent use.
-		Rand: handler.RandTLS(),
+		Rand: rand.FixedSize32Bytes(),
 		// TODO: Handle "VerifyPeerCertificate" for Certificate Transparency.
 	}
 

--- a/backend/internal/middleware/authentication/crypto/keyidentifier/keyidentifier_test.go
+++ b/backend/internal/middleware/authentication/crypto/keyidentifier/keyidentifier_test.go
@@ -8,12 +8,12 @@ package keyidentifier_test
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
-	"crypto/rand"
+	std "crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"h0llyw00dz-template/backend/internal/middleware/authentication/crypto/keyidentifier"
-	"h0llyw00dz-template/backend/internal/server"
+	"h0llyw00dz-template/backend/internal/middleware/authentication/crypto/rand"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -24,7 +24,7 @@ import (
 
 func TestKeyIdentifier(t *testing.T) {
 	// Generate an ECDSA private key
-	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), std.Reader)
 	if err != nil {
 		t.Fatalf("Failed to generate ECDSA private key: %v", err)
 	}
@@ -121,7 +121,7 @@ func TestKeyIdentifier(t *testing.T) {
 
 func TestKeyIdentifierWithFixedRand(t *testing.T) {
 	// Generate an ECDSA private key
-	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), server.RandTLS())
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.FixedSize32Bytes())
 	if err != nil {
 		t.Fatalf("Failed to generate ECDSA private key: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestKeyIdentifierWithFixedRand(t *testing.T) {
 		PrivateKey:       privateKey,
 		Digest:           sha256.New,
 		SignedContextKey: "signature",
-		Rand:             server.RandTLS(),
+		Rand:             rand.FixedSize32Bytes(),
 	})
 
 	// Extract the public key from the private key

--- a/backend/internal/middleware/authentication/crypto/rand/fixed_size.go
+++ b/backend/internal/middleware/authentication/crypto/rand/fixed_size.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// By accessing or using this software, you agree to be bound by the terms
+// of the License Agreement, which you can find at LICENSE files.
+
+// Note: The secure cryptographic random generator fixed size is moved here for easier maintenance.
+
+package rand
+
+import (
+	"crypto/rand"
+	"io"
+)
+
+// FixedSize32Bytes returns a custom [io.Reader] that provides a fixed-size random byte stream.
+// The returned reader generates 32 random bytes each time it is read from.
+// It uses the cryptographic random generator from the [crypto/rand] package to ensure secure randomness.
+//
+// The RandTLS function is suitable for use as the Rand field in [tls.Config] to provide
+// a source of entropy for nonces and RSA blinding. It ensures that the TLS package
+// always receives 32 random bytes when it requests random data.
+//
+// Example usage:
+//
+//	tlsConfig := &tls.Config{
+//		// ...
+//		Rand: rand.FixedSize32Bytes(),
+//		// ...
+//	}
+//
+// Note: This helper function is safe for use by multiple goroutines that call it simultaneously.
+// Also note that the fixed reader of 32 random bytes is a well-known entropy size for nonces and RSA blinding. When captured in Wireshark,
+// it is always unique. Plus, it is suitable for use by multiple goroutines because it provides an independent reader for each goroutine,
+// and the size cannot be changed or increased.
+func FixedSize32Bytes() io.Reader {
+	return &fixedReader{
+		size: 32,
+	}
+}
+
+// fixedReader is a custom [io.Reader] implementation that provides a fixed-size random byte stream.
+// It generates random bytes using the cryptographic random generator from the [crypto/rand] package.
+type fixedReader struct {
+	size int
+}
+
+// Read fills the provided byte slice p with random bytes up to the specified size.
+// It returns the number of bytes read (n) and any error encountered.
+//
+// If the length of p is 0, Read returns immediately with n=0 and err=nil.
+//
+// If the length of p is less than the specified size, Read fills the entire buffer p
+// with random bytes and returns the number of bytes read (n) and any error encountered.
+//
+// If the length of p is greater than or equal to the specified size, Read fills the first
+// size bytes of p with random bytes and returns the number of bytes read (n) and any error encountered.
+func (r *fixedReader) Read(p []byte) (n int, err error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if len(p) < r.size {
+		// If the provided buffer is smaller than the fixed size,
+		// read as much as possible and return the number of bytes read.
+		return rand.Read(p)
+	}
+
+	return rand.Read(p[:r.size])
+}

--- a/backend/internal/middleware/authentication/crypto/rand/rand_test.go
+++ b/backend/internal/middleware/authentication/crypto/rand/rand_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// By accessing or using this software, you agree to be bound by the terms
+// of the License Agreement, which you can find at LICENSE files.
+
+package rand_test
+
+import (
+	"h0llyw00dz-template/backend/internal/middleware/authentication/crypto/rand"
+	"testing"
+)
+
+func TestFixedSize32Bytes(t *testing.T) {
+	r := rand.FixedSize32Bytes()
+
+	// Test reading from the reader
+	buf := make([]byte, 32)
+	n, err := r.Read(buf)
+
+	// Check the number of bytes read
+	if n != 32 {
+		t.Errorf("Expected to read 32 bytes, but read %d bytes", n)
+	}
+
+	// Check for any errors
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	// Test reading again to ensure it generates new random bytes
+	buf2 := make([]byte, 32)
+	_, err = r.Read(buf2)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	// Check that the two reads generate different random bytes
+	if string(buf) == string(buf2) {
+		t.Error("Expected different random bytes on subsequent reads")
+	}
+}
+
+func TestFixedReaderRead(t *testing.T) {
+	r := rand.FixedSize32Bytes()
+
+	// Test reading with a buffer smaller than the fixed size
+	buf := make([]byte, 16)
+	n, err := r.Read(buf)
+
+	// Check the number of bytes read
+	if n != 16 {
+		t.Errorf("Expected to read 16 bytes, but read %d bytes", n)
+	}
+
+	// Check for any errors
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	// Test reading with a buffer larger than the fixed size
+	buf = make([]byte, 64)
+	n, err = r.Read(buf)
+
+	// Check the number of bytes read
+	if n != 32 {
+		t.Errorf("Expected to read 32 bytes, but read %d bytes", n)
+	}
+
+	// Check for any errors
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	// Test reading with an empty buffer
+	buf = make([]byte, 0)
+	n, err = r.Read(buf)
+
+	// Check the number of bytes read
+	if n != 0 {
+		t.Errorf("Expected to read 0 bytes, but read %d bytes", n)
+	}
+
+	// Check for any errors
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}

--- a/backend/internal/server/boringtls_cert.go
+++ b/backend/internal/server/boringtls_cert.go
@@ -16,6 +16,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"h0llyw00dz-template/backend/internal/middleware/authentication/crypto/rand"
 	"io"
 	"net/http"
 	"time"
@@ -143,7 +144,7 @@ func (s *FiberServer) SubmitToCTLog(cert *x509.Certificate, privateKey crypto.Pr
 	// Note: The [RandTLS()] function provides sufficient randomness for the purposes of [x509.CreateCertificate],
 	// including generating serial numbers and signing certificates with any type of key,
 	// instead of multiple calls to [io.Reader], following DRY (Don't Repeat Yourself).
-	certDER, err := x509.CreateCertificate(RandTLS(), cert, cert, publicKey(privateKey), privateKey)
+	certDER, err := x509.CreateCertificate(rand.FixedSize32Bytes(), cert, cert, publicKey(privateKey), privateKey)
 	if err != nil {
 		return fmt.Errorf("failed to encode certificate: %v", err)
 	}

--- a/backend/internal/server/ct_verifier_test.go
+++ b/backend/internal/server/ct_verifier_test.go
@@ -6,7 +6,7 @@
 package server_test
 
 import (
-	"crypto/rand"
+	std "crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
@@ -15,6 +15,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"h0llyw00dz-template/backend/internal/middleware/authentication/crypto/hybrid/stream"
+	"h0llyw00dz-template/backend/internal/middleware/authentication/crypto/rand"
 	"h0llyw00dz-template/backend/internal/server"
 	"math/big"
 	"testing"
@@ -84,7 +85,7 @@ func TestVerifyCertificateTransparencyInTLSConnection(t *testing.T) {
 			tls.CurveP384,
 			tls.CurveP521,
 		},
-		Rand: server.RandTLS(),
+		Rand: rand.FixedSize32Bytes(),
 		Certificates: []tls.Certificate{
 			{
 				Certificate: [][]byte{cert.Raw},
@@ -210,7 +211,7 @@ func TestInvalidSCT(t *testing.T) {
 	ctVerifier := new(server.CTVerifier)
 
 	// Generate a random serial number
-	serialNumber, err := rand.Int(rand.Reader, big.NewInt(1<<62))
+	serialNumber, err := std.Int(std.Reader, big.NewInt(1<<62))
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -242,7 +243,7 @@ func TestInvalidSCT(t *testing.T) {
 		}
 
 		// Generate a new RSA private key
-		privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		privateKey, err := rsa.GenerateKey(std.Reader, 2048)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -260,7 +261,7 @@ func TestInvalidSCT(t *testing.T) {
 		}
 
 		// Create a self-signed certificate
-		certx, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+		certx, err := x509.CreateCertificate(std.Reader, &template, &template, &privateKey.PublicKey, privateKey)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -298,7 +299,7 @@ func TestInvalidSCT(t *testing.T) {
 		}
 
 		// Generate a new RSA private key
-		privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		privateKey, err := rsa.GenerateKey(std.Reader, 2048)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}
@@ -316,7 +317,7 @@ func TestInvalidSCT(t *testing.T) {
 		}
 
 		// Create a self-signed certificate
-		certx, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+		certx, err := x509.CreateCertificate(std.Reader, &template, &template, &privateKey.PublicKey, privateKey)
 		if err != nil {
 			t.Errorf("Unexpected error: %v", err)
 		}

--- a/backend/internal/server/helper.go
+++ b/backend/internal/server/helper.go
@@ -7,11 +7,9 @@ package server
 
 import (
 	"bytes"
-	"crypto/rand"
 	"crypto/tls"
 	"fmt"
 	"h0llyw00dz-template/backend/internal/database"
-	"io"
 	"net/http"
 	"time"
 
@@ -111,62 +109,6 @@ func isBrowserRequest(data []byte) bool {
 	}
 
 	return false
-}
-
-// RandTLS returns a custom [io.Reader] that provides a fixed-size random byte stream.
-// The returned reader generates 32 random bytes each time it is read from.
-// It uses the cryptographic random generator from the [crypto/rand] package to ensure secure randomness.
-//
-// The RandTLS function is suitable for use as the Rand field in [tls.Config] to provide
-// a source of entropy for nonces and RSA blinding. It ensures that the TLS package
-// always receives 32 random bytes when it requests random data.
-//
-// Example usage:
-//
-//	tlsConfig := &tls.Config{
-//		// ...
-//		Rand: handler.RandTLS(),
-//		// ...
-//	}
-//
-// Note: This helper function is safe for use by multiple goroutines that call it simultaneously.
-// Also note that the fixed reader of 32 random bytes is a well-known entropy size for nonces and RSA blinding. When captured in Wireshark,
-// it is always unique. Plus, it is suitable for use by multiple goroutines because it provides an independent reader for each goroutine,
-// and the size cannot be changed or increased.
-func RandTLS() io.Reader {
-	return &fixedReader{
-		size: 32,
-	}
-}
-
-// fixedReader is a custom [io.Reader] implementation that provides a fixed-size random byte stream.
-// It generates random bytes using the cryptographic random generator from the [crypto/rand] package.
-type fixedReader struct {
-	size int
-}
-
-// Read fills the provided byte slice p with random bytes up to the specified size.
-// It returns the number of bytes read (n) and any error encountered.
-//
-// If the length of p is 0, Read returns immediately with n=0 and err=nil.
-//
-// If the length of p is less than the specified size, Read fills the entire buffer p
-// with random bytes and returns the number of bytes read (n) and any error encountered.
-//
-// If the length of p is greater than or equal to the specified size, Read fills the first
-// size bytes of p with random bytes and returns the number of bytes read (n) and any error encountered.
-func (r *fixedReader) Read(p []byte) (n int, err error) {
-	if len(p) == 0 {
-		return 0, nil
-	}
-	if len(p) < r.size {
-		// If the provided buffer is smaller than the fixed size,
-		// read as much as possible and return the number of bytes read.
-		return rand.Read(p)
-	}
-
-	// Note: If [rand.Read] fails to generate random bytes, it will be handled by the standard library [crypto/tls] package internally, and you don't need to know about it.
-	return rand.Read(p[:r.size])
 }
 
 // MakeHTTPRequest is a helper function that makes an HTTP request using TLS 1.3.

--- a/backend/internal/server/helper_tls_test.go
+++ b/backend/internal/server/helper_tls_test.go
@@ -13,7 +13,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/elliptic"
-	"crypto/rand"
+	std "crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
@@ -22,6 +22,7 @@ import (
 	"encoding/base64"
 	"errors"
 	log "h0llyw00dz-template/backend/internal/logger"
+	"h0llyw00dz-template/backend/internal/middleware/authentication/crypto/rand"
 	"h0llyw00dz-template/backend/internal/server"
 	"math/big"
 	"net/http"
@@ -117,7 +118,7 @@ func tlsServerConfig(cert tls.Certificate) *tls.Config {
 		// defaults to verifying client certificates when ClientCAs is set.
 		// Also, note that ClientCAs refers to the chain of Certificate Authorities Pool that made & signed by RootCAs, which is why it's different from RootCAs.
 		ClientAuth: tls.RequireAndVerifyClientCert,
-		Rand:       server.RandTLS(),
+		Rand:       rand.FixedSize32Bytes(),
 	}
 }
 
@@ -161,12 +162,12 @@ func (m *MockHTTPClient) Do(req *http.Request) (*http.Response, error) {
 }
 
 func generateSelfSignedCertECDSA() (*x509.Certificate, *ecdsa.PrivateKey, error) {
-	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), std.Reader)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	serialNumber, err := std.Int(std.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -184,7 +185,7 @@ func generateSelfSignedCertECDSA() (*x509.Certificate, *ecdsa.PrivateKey, error)
 		BasicConstraintsValid: true,
 	}
 
-	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	derBytes, err := x509.CreateCertificate(std.Reader, &template, &template, &privateKey.PublicKey, privateKey)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -198,12 +199,12 @@ func generateSelfSignedCertECDSA() (*x509.Certificate, *ecdsa.PrivateKey, error)
 }
 
 func generateSelfSignedCertRSA() (*x509.Certificate, *rsa.PrivateKey, error) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	privateKey, err := rsa.GenerateKey(std.Reader, 2048)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	serialNumber, err := std.Int(std.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -221,7 +222,7 @@ func generateSelfSignedCertRSA() (*x509.Certificate, *rsa.PrivateKey, error) {
 		BasicConstraintsValid: true,
 	}
 
-	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	derBytes, err := x509.CreateCertificate(std.Reader, &template, &template, &privateKey.PublicKey, privateKey)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -238,7 +239,7 @@ func generateSelfSignedCertEd25519() (*x509.Certificate, ed25519.PrivateKey, err
 	privateKey := ed25519.NewKeyFromSeed(make([]byte, ed25519.SeedSize))
 	publicKey := privateKey.Public().(ed25519.PublicKey)
 
-	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	serialNumber, err := std.Int(std.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -256,7 +257,7 @@ func generateSelfSignedCertEd25519() (*x509.Certificate, ed25519.PrivateKey, err
 		BasicConstraintsValid: true,
 	}
 
-	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey, privateKey)
+	derBytes, err := x509.CreateCertificate(std.Reader, &template, &template, publicKey, privateKey)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -273,7 +274,7 @@ func generateSelfSignedCertEd25519WithExpired() (*x509.Certificate, ed25519.Priv
 	privateKey := ed25519.NewKeyFromSeed(make([]byte, ed25519.SeedSize))
 	publicKey := privateKey.Public().(ed25519.PublicKey)
 
-	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	serialNumber, err := std.Int(std.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -291,7 +292,7 @@ func generateSelfSignedCertEd25519WithExpired() (*x509.Certificate, ed25519.Priv
 		BasicConstraintsValid: true,
 	}
 
-	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey, privateKey)
+	derBytes, err := x509.CreateCertificate(std.Reader, &template, &template, publicKey, privateKey)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -307,12 +308,12 @@ func generateSelfSignedCertEd25519WithExpired() (*x509.Certificate, ed25519.Priv
 // createTestCertificateWithSCTs creates a test certificate with SCTs for testing purposes.
 func createTestCertificateWithSCTs(t *testing.T) (*x509.Certificate, *server.SCTResponse) {
 	// Generate an ECDSA private key
-	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), std.Reader)
 	if err != nil {
 		t.Fatalf("Failed to generate ECDSA private key: %v", err)
 	}
 
-	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	serialNumber, err := std.Int(std.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
 	if err != nil {
 		t.Fatalf("Failed to generate serial number: %v", err)
 	}
@@ -320,7 +321,7 @@ func createTestCertificateWithSCTs(t *testing.T) (*x509.Certificate, *server.SCT
 	// Create SCT data with a valid timestamp
 	timestamp := uint64(time.Now().Unix())
 	logID := make([]byte, 32)
-	_, err = rand.Read(logID)
+	_, err = std.Read(logID)
 	if err != nil {
 		t.Fatalf("Failed to generate log ID: %v", err)
 	}
@@ -341,7 +342,7 @@ func createTestCertificateWithSCTs(t *testing.T) (*x509.Certificate, *server.SCT
 	sctData = append(sctData, byte(len(extensions)))
 	sctData = append(sctData, extensions...)
 
-	signature, err := ecdsa.SignASN1(rand.Reader, privateKey, sctData)
+	signature, err := ecdsa.SignASN1(std.Reader, privateKey, sctData)
 	if err != nil {
 		t.Fatalf("Failed to generate signature: %v", err)
 	}
@@ -383,7 +384,7 @@ func createTestCertificateWithSCTs(t *testing.T) (*x509.Certificate, *server.SCT
 	}
 
 	// Create the self-signed certificate
-	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	derBytes, err := x509.CreateCertificate(std.Reader, &template, &template, &privateKey.PublicKey, privateKey)
 	if err != nil {
 		t.Fatalf("Failed to create self-signed certificate: %v", err)
 	}
@@ -399,12 +400,12 @@ func createTestCertificateWithSCTs(t *testing.T) (*x509.Certificate, *server.SCT
 // createTestCertificateValidSCTs creates a test certificate valid SCTs for testing purposes.
 func createTestCertificateValidSCTs(t *testing.T) (*x509.Certificate, *server.SCTResponse) {
 	// Generate an ECDSA private key
-	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), std.Reader)
 	if err != nil {
 		t.Fatalf("Failed to generate ECDSA private key: %v", err)
 	}
 
-	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	serialNumber, err := std.Int(std.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
 	if err != nil {
 		t.Fatalf("Failed to generate serial number: %v", err)
 	}
@@ -429,7 +430,7 @@ func createTestCertificateValidSCTs(t *testing.T) (*x509.Certificate, *server.SC
 	}
 
 	// Create the self-signed certificate
-	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	derBytes, err := x509.CreateCertificate(std.Reader, &template, &template, &privateKey.PublicKey, privateKey)
 	if err != nil {
 		t.Fatalf("Failed to create self-signed certificate: %v", err)
 	}
@@ -455,7 +456,7 @@ func createTestCertificateValidSCTs(t *testing.T) (*x509.Certificate, *server.SC
 		byte(timestamp))
 	data = append(data, []byte("")...)
 
-	signature, err := ecdsa.SignASN1(rand.Reader, privateKey, data)
+	signature, err := ecdsa.SignASN1(std.Reader, privateKey, data)
 	if err != nil {
 		t.Fatalf("Failed to generate signature: %v", err)
 	}
@@ -491,7 +492,7 @@ func generateSCTExtension(SCData server.SCTData) (pkix.Extension, error) {
 // createTestCertificateValidSCTsForLTS creates a test certificate valid SCTs for testing purposes.
 func createTestCertificateValidSCTsForLTS(t *testing.T) (*x509.Certificate, crypto.PrivateKey) {
 	// Generate a random serial number
-	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	serialNumber, err := std.Int(std.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
 	if err != nil {
 		t.Fatalf("Failed to generate serial number: %v", err)
 	}
@@ -520,13 +521,13 @@ func createTestCertificateValidSCTsForLTS(t *testing.T) (*x509.Certificate, cryp
 	}
 
 	// Generate a new ECDSA private key
-	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), std.Reader)
 	if err != nil {
 		t.Fatalf("Failed to generate private key: %v", err)
 	}
 
 	// Create a self-signed certificate
-	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	derBytes, err := x509.CreateCertificate(std.Reader, &template, &template, &privateKey.PublicKey, privateKey)
 	if err != nil {
 		t.Fatalf("Failed to create certificate: %v", err)
 	}
@@ -540,7 +541,7 @@ func createTestCertificateValidSCTsForLTS(t *testing.T) (*x509.Certificate, cryp
 	// Create SCT data with a valid timestamp
 	timestamp := uint64(time.Now().Unix())
 	logID := make([]byte, 32)
-	_, err = rand.Read(logID)
+	_, err = std.Read(logID)
 	if err != nil {
 		t.Fatalf("Failed to generate log ID: %v", err)
 	}
@@ -567,7 +568,7 @@ func createTestCertificateValidSCTsForLTS(t *testing.T) (*x509.Certificate, cryp
 	hasher := hash.New()
 	hasher.Write(sctData)
 	hashed := hasher.Sum(nil)
-	signature, err := ecdsa.SignASN1(rand.Reader, privateKey, hashed)
+	signature, err := ecdsa.SignASN1(std.Reader, privateKey, hashed)
 	if err != nil {
 		t.Fatalf("Failed to generate signature: %v", err)
 	}
@@ -596,7 +597,7 @@ func createTestCertificateValidSCTsForLTS(t *testing.T) (*x509.Certificate, cryp
 	})
 
 	// Create a new certificate with the SCT extension
-	certWithSCT, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	certWithSCT, err := x509.CreateCertificate(std.Reader, &template, &template, &privateKey.PublicKey, privateKey)
 	if err != nil {
 		t.Fatalf("Failed to create certificate with SCT: %v", err)
 	}


### PR DESCRIPTION
- [+] refactor(backend): move RandTLS function to separate rand package
- [+] refactor(backend): update references to RandTLS function to use rand.FixedSize32Bytes
- [+] test(backend): add tests for FixedSize32Bytes function in rand package
- [+] refactor(backend): update tests to use std.Reader instead of rand.Reader
- [+] test(backend): add tests for fixedReader Read method in rand package