### PR TITLE
Feat [SetupFiber] for running behind an ingress controller/proxy

### DIFF
--- a/backend/cmd/server/run.go
+++ b/backend/cmd/server/run.go
@@ -83,6 +83,15 @@ func setupFiber(appName string, readTimeout, writeTimeout time.Duration) *fiber.
 		Prefork: false,
 		// Which is suitable for streaming AI Response.
 		StreamRequestBody: true,
+		// When running behind an ingress controller/proxy, disable "EnableIPValidation"
+		// because the ingress controller/proxy will forward the real IP anyway from the header, which is already valid.
+		EnableIPValidation:      false,
+		EnableTrustedProxyCheck: true,
+		// By default, it is set to 0.0.0.0/0 for local development; however, it can be bound to an ingress controller/proxy.
+		// This can be a private IP range (e.g., 10.0.0.0/8).
+		TrustedProxies: []string{"0.0.0.0/0"},
+		// Trust X-Forwarded-* headers; additionally, this can be customized if using an ingress controller/proxy, especially Ingress Nginx.
+		ProxyHeader: "X-Forwarded-*",
 	})
 }
 


### PR DESCRIPTION
- [+] feat(server): add support for running behind an ingress controller/proxy
- [+] disable EnableIPValidation
- [+] enable EnableTrustedProxyCheck
- [+] set TrustedProxies to 0.0.0.0/0 by default
- [+] trust X-Forwarded-* headers