### PR TITLE
Refactor [Frontend] [HTMX+TEMPL] Meta Tag

### DIFF
--- a/frontend/htmx/site/head.templ
+++ b/frontend/htmx/site/head.templ
@@ -18,6 +18,9 @@ templ (c Component) Head() {
 	<head>
 		<meta charset="utf-8"/>
 		<meta name="viewport" content="width=device-width, initial-scale=1"/>
+		<meta name="msapplication-TileColor" content="#da532c"/>
+		<meta name="theme-color" content="#2596BE"/>
+		<meta name="description" content="Witness the elegance and efficiency of web development with Go and HTMX. This website, purely written in Go and powered by HTMX's dynamic interactions, showcases how the combination of Go's simplicity and performance creates a seamless and engaging user experience."/>
 		@subHead()
 		// TODO: Enhance CSS/JS delivery by implementing a system that generates unique filenames based on UUIDs or cryptographic hashes.
 		// When a client visits the website, they would receive CSS/JS files with names like "randomuuid.css" or "hash.js", where the randomuuid or hash portion is secure dynamically generated.
@@ -46,14 +49,6 @@ templ subHead() {
 		<link rel="icon" type="image/png" sizes="32x32" href="/styles/images/favicon-32x32.png"/>
 		<link rel="icon" type="image/png" sizes="16x16" href="/styles/images/favicon-16x16.png"/>
 		<link rel="mask-icon" href="/styles/images/safari-pinned-tab.svg" color="#5bbad5"/>
-		<meta name="msapplication-TileColor" content="#da532c"/>
-		<meta name="theme-color" content="#2596BE"/>
-		<meta
-			name="description"
-			content="Witness the elegance and efficiency of web development with Go and HTMX. 
-			This website, purely written in Go and powered by HTMX's dynamic interactions, 
-			showcases how the combination of Go's simplicity and performance creates a seamless and engaging user experience."
-		/>
 		<link rel="manifest" href="/styles/images/site.webmanifest"/>
 	}
 }

--- a/frontend/htmx/site/head_templ.go
+++ b/frontend/htmx/site/head_templ.go
@@ -43,7 +43,7 @@ func (c Component) Head() templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"><meta name=\"msapplication-TileColor\" content=\"#da532c\"><meta name=\"theme-color\" content=\"#2596BE\"><meta name=\"description\" content=\"Witness the elegance and efficiency of web development with Go and HTMX. This website, purely written in Go and powered by HTMX&#39;s dynamic interactions, showcases how the combination of Go&#39;s simplicity and performance creates a seamless and engaging user experience.\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -58,7 +58,7 @@ func (c Component) Head() templ.Component {
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(c.CspRandom)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `frontend/htmx/site/head.templ`, Line: 26, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `frontend/htmx/site/head.templ`, Line: 29, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
@@ -79,7 +79,7 @@ func (c Component) Head() templ.Component {
 		var templ_7745c5c3_Var3 string
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(c.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `frontend/htmx/site/head.templ`, Line: 28, Col: 18}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `frontend/htmx/site/head.templ`, Line: 31, Col: 18}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
@@ -171,7 +171,7 @@ func subHead() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"/styles/images/apple-touch-icon.png\"><link rel=\"icon\" type=\"image/png\" sizes=\"32x32\" href=\"/styles/images/favicon-32x32.png\"><link rel=\"icon\" type=\"image/png\" sizes=\"16x16\" href=\"/styles/images/favicon-16x16.png\"><link rel=\"mask-icon\" href=\"/styles/images/safari-pinned-tab.svg\" color=\"#5bbad5\"><meta name=\"msapplication-TileColor\" content=\"#da532c\"><meta name=\"theme-color\" content=\"#2596BE\"><meta name=\"description\" content=\"Witness the elegance and efficiency of web development with Go and HTMX. \r\n\t\t\tThis website, purely written in Go and powered by HTMX&#39;s dynamic interactions, \r\n\t\t\tshowcases how the combination of Go&#39;s simplicity and performance creates a seamless and engaging user experience.\"><link rel=\"manifest\" href=\"/styles/images/site.webmanifest\">")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"/styles/images/apple-touch-icon.png\"><link rel=\"icon\" type=\"image/png\" sizes=\"32x32\" href=\"/styles/images/favicon-32x32.png\"><link rel=\"icon\" type=\"image/png\" sizes=\"16x16\" href=\"/styles/images/favicon-16x16.png\"><link rel=\"mask-icon\" href=\"/styles/images/safari-pinned-tab.svg\" color=\"#5bbad5\"><link rel=\"manifest\" href=\"/styles/images/site.webmanifest\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}


### PR DESCRIPTION
- [+] refactor(head.templ): move meta tags for TileColor, theme-color, and description to the top of the head section

Note: This refactor enhances the HTML source by formatting it into a single line.