### PR TITLE
Update Go Version to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module h0llyw00dz-template
 
-go 1.22.6
+go 1.23.0
 
 require (
 	github.com/H0llyW00dzZ/FiberValidator v0.5.2


### PR DESCRIPTION
- [+] chore(go.mod): update go version from 1.22.6 to 1.23.0

Note: If encounter a "NULL" error due to a corrupted go.sum file, try deleting the go.sum file and running the following commands:
1. `go env -w GOSUMDB=off`
2. `go mod tidy`