### PR TITLE
TODO: [REST APIs Error Handler] Deprecate ErrorHandler function

### DIFF
--- a/backend/pkg/restapis/helper/restapis_error.go
+++ b/backend/pkg/restapis/helper/restapis_error.go
@@ -41,6 +41,8 @@ func SendErrorResponse(c *fiber.Ctx, statusCode int, errorMessage string) error 
 }
 
 // ErrorHandler is the error handling middleware that runs after other middleware.
+//
+// TODO: Deprecate/Remove This Function - it will be replaced by [htmx.NewErrorHandler] when the [middleware.RegisterRoutes] is reorganized.
 func ErrorHandler(c *fiber.Ctx) error {
 	// Call the next route handler and catch any errors
 	err := c.Next()

--- a/backend/pkg/restapis/helper/restapis_error_test.go
+++ b/backend/pkg/restapis/helper/restapis_error_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"h0llyw00dz-template/backend/pkg/restapis/helper"
+	htmx "h0llyw00dz-template/frontend/htmx/error_page_handler"
 
 	"github.com/bytedance/sonic"
 	"github.com/gofiber/fiber/v2"
@@ -316,7 +317,7 @@ func TestErrorHandler(t *testing.T) {
 	app := fiber.New()
 
 	// Register the ErrorHandler (for handling panic) & Recover middleware
-	app.Use(helper.ErrorHandler, recover.New())
+	app.Use(htmx.NewErrorHandler, recover.New())
 
 	// Create a test route that panics
 	app.Get("/gopher/test", func(c *fiber.Ctx) error {


### PR DESCRIPTION
- [+] refactor(restapis_error.go): add TODO comment to deprecate ErrorHandler function
- [+] refactor(restapis_error_test.go): replace helper.ErrorHandler with htmx.NewErrorHandler in TestErrorHandler