### PR TITLE
Implement [Backend] [pkg] MIME Constant Package

### DIFF
--- a/backend/internal/middleware/routes.go
+++ b/backend/internal/middleware/routes.go
@@ -16,6 +16,7 @@ import (
 	"h0llyw00dz-template/backend/internal/database"
 	log "h0llyw00dz-template/backend/internal/logger"
 	"h0llyw00dz-template/backend/internal/middleware/authentication/crypto/keyidentifier"
+	"h0llyw00dz-template/backend/pkg/mime"
 	"h0llyw00dz-template/backend/pkg/restapis/helper"
 	"h0llyw00dz-template/env"
 	htmx "h0llyw00dz-template/frontend/htmx/error_page_handler"
@@ -132,8 +133,9 @@ func registerRouteConfigMiddleware(app *fiber.App, db database.Service) {
 				fiber.MIMETextHTMLCharsetUTF8,
 				fiber.MIMEApplicationJSON,
 				fiber.MIMEApplicationJSONCharsetUTF8,
-				helper.MIMEApplicationProblemJSON,
-				helper.MIMEApplicationProblemJSONCharsetUTF8,
+				mime.ApplicationProblemJSON,
+				mime.ApplicationProblemJSONCharsetUTF8,
+				mime.TextEventStream,
 			),
 		),
 		WithCacheHeader("X-Go-Frontend"),

--- a/backend/pkg/mime/docs.go
+++ b/backend/pkg/mime/docs.go
@@ -1,0 +1,7 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// By accessing or using this software, you agree to be bound by the terms
+// of the License Agreement, which you can find at LICENSE files.
+
+// Package mime provides constants for MIME types and related implementations and enhancements that are not covered by the standard library or the Fiber package.
+package mime

--- a/backend/pkg/mime/mime.go
+++ b/backend/pkg/mime/mime.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2024 H0llyW00dz All rights reserved.
+//
+// By accessing or using this software, you agree to be bound by the terms
+// of the License Agreement, which you can find at LICENSE files.
+
+package mime
+
+const (
+	// ApplicationProblemJSON represents the MIME type for problem+json (RFC 7807).
+	// It is used to indicate that the response body contains a problem details object
+	// serialized using the JSON format.
+	ApplicationProblemJSON = "application/problem+json"
+
+	// ApplicationProblemJSONCharsetUTF8 represents the MIME type for problem+json
+	// with UTF-8 charset (RFC 7807 Enhancement).
+	ApplicationProblemJSONCharsetUTF8 = "application/problem+json; charset=utf-8"
+)
+
+const (
+	// TextEventStream represents the MIME type for text/event-stream.
+	//
+	// It is used to indicate that the response body contains a stream of server-sent events (SSE).
+	// Server-sent events allow the server to push updates to the client in real-time over a
+	// long-lived HTTP connection.
+	//
+	// The event stream consists of a series of event messages, where each message is a single
+	// line of text terminated by a newline character. The message format includes fields such
+	// as "event", "data", "id", and "retry" to convey event information.
+	//
+	// Example usage:
+	//
+	//	w.Header().Set("Content-Type", MIMETextEventStream)
+	//	w.Write([]byte("event: update\ndata: {\"message\": \"Hello, world!\"}\n\n"))
+	//	w.Flush()
+	//
+	// See the Server-Sent Events specification for more details:
+	// https://html.spec.whatwg.org/multipage/server-sent-events.html
+	//
+	// Note: This suitable for AI
+	TextEventStream = "text/event-stream"
+)

--- a/backend/pkg/mime/mime.go
+++ b/backend/pkg/mime/mime.go
@@ -29,7 +29,7 @@ const (
 	//
 	// Example usage:
 	//
-	//	w.Header().Set("Content-Type", MIMETextEventStream)
+	//	w.Header().Set("Content-Type", mime.TextEventStream)
 	//	w.Write([]byte("event: update\ndata: {\"message\": \"Hello, world!\"}\n\n"))
 	//	w.Flush()
 	//

--- a/backend/pkg/restapis/helper/restapis_error.go
+++ b/backend/pkg/restapis/helper/restapis_error.go
@@ -5,22 +5,17 @@
 
 package helper
 
-import "github.com/gofiber/fiber/v2"
+import (
+	"h0llyw00dz-template/backend/pkg/mime"
+
+	"github.com/gofiber/fiber/v2"
+)
 
 // ErrorResponse represents the structure of an error response.
 type ErrorResponse struct {
 	Code  int    `json:"code"`
 	Error string `json:"error"`
 }
-
-const (
-
-	// MIMEApplicationProblemJSON represents the MIME type for problem+json (RFC 7807).
-	MIMEApplicationProblemJSON = "application/problem+json"
-
-	// MIMEApplicationProblemJSONCharsetUTF8 represents the MIME type for problem+json with UTF-8 charset (RFC 7807 Enhancement).
-	MIMEApplicationProblemJSONCharsetUTF8 = "application/problem+json; charset=utf-8"
-)
 
 // SendErrorResponse sends an error response with the specified status code and error message.
 func SendErrorResponse(c *fiber.Ctx, statusCode int, errorMessage string) error {
@@ -30,14 +25,14 @@ func SendErrorResponse(c *fiber.Ctx, statusCode int, errorMessage string) error 
 		return c.Status(statusCode).JSON(ErrorResponse{
 			Code:  statusCode,
 			Error: errorMessage,
-		}, MIMEApplicationProblemJSONCharsetUTF8)
+		}, mime.ApplicationProblemJSONCharsetUTF8)
 	}
 
 	// If the response body contains only ASCII characters, use the MIME type without charset
 	return c.Status(statusCode).JSON(ErrorResponse{
 		Code:  statusCode,
 		Error: errorMessage,
-	}, MIMEApplicationProblemJSON)
+	}, mime.ApplicationProblemJSON)
 }
 
 // ErrorHandler is the error handling middleware that runs after other middleware.

--- a/backend/pkg/restapis/helper/restapis_error_test.go
+++ b/backend/pkg/restapis/helper/restapis_error_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"h0llyw00dz-template/backend/pkg/mime"
 	"h0llyw00dz-template/backend/pkg/restapis/helper"
 	htmx "h0llyw00dz-template/frontend/htmx/error_page_handler"
 
@@ -34,8 +35,8 @@ func TestSendErrorResponse_BadRequest(t *testing.T) {
 	}
 
 	contentType := resp.Header.Get("Content-Type")
-	if contentType != helper.MIMEApplicationProblemJSON {
-		t.Errorf("Expected Content-Type '%s', got '%s'", helper.MIMEApplicationProblemJSON, contentType)
+	if contentType != mime.ApplicationProblemJSON {
+		t.Errorf("Expected Content-Type '%s', got '%s'", mime.ApplicationProblemJSON, contentType)
 	}
 
 	var errorResponse helper.ErrorResponse
@@ -71,8 +72,8 @@ func TestSendErrorResponse_Unauthorized(t *testing.T) {
 	}
 
 	contentType := resp.Header.Get("Content-Type")
-	if contentType != helper.MIMEApplicationProblemJSON {
-		t.Errorf("Expected Content-Type '%s', got '%s'", helper.MIMEApplicationProblemJSON, contentType)
+	if contentType != mime.ApplicationProblemJSON {
+		t.Errorf("Expected Content-Type '%s', got '%s'", mime.ApplicationProblemJSON, contentType)
 	}
 
 	var errorResponse helper.ErrorResponse
@@ -108,8 +109,8 @@ func TestSendErrorResponse_Forbidden(t *testing.T) {
 	}
 
 	contentType := resp.Header.Get("Content-Type")
-	if contentType != helper.MIMEApplicationProblemJSON {
-		t.Errorf("Expected Content-Type '%s', got '%s'", helper.MIMEApplicationProblemJSON, contentType)
+	if contentType != mime.ApplicationProblemJSON {
+		t.Errorf("Expected Content-Type '%s', got '%s'", mime.ApplicationProblemJSON, contentType)
 	}
 
 	var errorResponse helper.ErrorResponse
@@ -145,8 +146,8 @@ func TestSendErrorResponse_NotFound(t *testing.T) {
 	}
 
 	contentType := resp.Header.Get("Content-Type")
-	if contentType != helper.MIMEApplicationProblemJSON {
-		t.Errorf("Expected Content-Type '%s', got '%s'", helper.MIMEApplicationProblemJSON, contentType)
+	if contentType != mime.ApplicationProblemJSON {
+		t.Errorf("Expected Content-Type '%s', got '%s'", mime.ApplicationProblemJSON, contentType)
 	}
 
 	var errorResponse helper.ErrorResponse
@@ -182,8 +183,8 @@ func TestSendErrorResponse_Conflict(t *testing.T) {
 	}
 
 	contentType := resp.Header.Get("Content-Type")
-	if contentType != helper.MIMEApplicationProblemJSON {
-		t.Errorf("Expected Content-Type '%s', got '%s'", helper.MIMEApplicationProblemJSON, contentType)
+	if contentType != mime.ApplicationProblemJSON {
+		t.Errorf("Expected Content-Type '%s', got '%s'", mime.ApplicationProblemJSON, contentType)
 	}
 
 	var errorResponse helper.ErrorResponse
@@ -219,8 +220,8 @@ func TestSendErrorResponse_BadGateway(t *testing.T) {
 	}
 
 	contentType := resp.Header.Get("Content-Type")
-	if contentType != helper.MIMEApplicationProblemJSON {
-		t.Errorf("Expected Content-Type '%s', got '%s'", helper.MIMEApplicationProblemJSON, contentType)
+	if contentType != mime.ApplicationProblemJSON {
+		t.Errorf("Expected Content-Type '%s', got '%s'", mime.ApplicationProblemJSON, contentType)
 	}
 
 	var errorResponse helper.ErrorResponse
@@ -256,8 +257,8 @@ func TestSendErrorResponse_InternalServerError(t *testing.T) {
 	}
 
 	contentType := resp.Header.Get("Content-Type")
-	if contentType != helper.MIMEApplicationProblemJSON {
-		t.Errorf("Expected Content-Type '%s', got '%s'", helper.MIMEApplicationProblemJSON, contentType)
+	if contentType != mime.ApplicationProblemJSON {
+		t.Errorf("Expected Content-Type '%s', got '%s'", mime.ApplicationProblemJSON, contentType)
 	}
 
 	var errorResponse helper.ErrorResponse
@@ -293,8 +294,8 @@ func TestSendErrorResponse_TooManyRequests(t *testing.T) {
 	}
 
 	contentType := resp.Header.Get("Content-Type")
-	if contentType != helper.MIMEApplicationProblemJSON {
-		t.Errorf("Expected Content-Type '%s', got '%s'", helper.MIMEApplicationProblemJSON, contentType)
+	if contentType != mime.ApplicationProblemJSON {
+		t.Errorf("Expected Content-Type '%s', got '%s'", mime.ApplicationProblemJSON, contentType)
 	}
 
 	var errorResponse helper.ErrorResponse
@@ -336,8 +337,8 @@ func TestErrorHandler(t *testing.T) {
 	}
 
 	contentType := resp.Header.Get("Content-Type")
-	if contentType != helper.MIMEApplicationProblemJSON {
-		t.Errorf("Expected Content-Type '%s', got '%s'", helper.MIMEApplicationProblemJSON, contentType)
+	if contentType != mime.ApplicationProblemJSON {
+		t.Errorf("Expected Content-Type '%s', got '%s'", mime.ApplicationProblemJSON, contentType)
 	}
 
 	var errorResponse helper.ErrorResponse
@@ -373,8 +374,8 @@ func TestSendErrorResponse_InternalServerError_NonASCII(t *testing.T) {
 	}
 
 	contentType := resp.Header.Get("Content-Type")
-	if contentType != helper.MIMEApplicationProblemJSONCharsetUTF8 {
-		t.Errorf("Expected Content-Type '%s', got '%s'", helper.MIMEApplicationProblemJSONCharsetUTF8, contentType)
+	if contentType != mime.ApplicationProblemJSONCharsetUTF8 {
+		t.Errorf("Expected Content-Type '%s', got '%s'", mime.ApplicationProblemJSONCharsetUTF8, contentType)
 	}
 
 	var errorResponse helper.ErrorResponse


### PR DESCRIPTION
- [+] feat(mime): add mime package with constants for MIME types
- [+] refactor(helper): use mime constants from new mime package in restapis_error.go
- [+] test(helper): update tests in restapis_error_test.go to use mime constants
- [+] docs(mime): add package documentation for mime package
- [+] chore(middleware): add mime.TextEventStream to allowed content types in routes.go