### PR TITLE
Enhance [REST APIs Router] Redirect Endpoint

### DIFF
--- a/backend/internal/middleware/restapis_routes.go
+++ b/backend/internal/middleware/restapis_routes.go
@@ -111,17 +111,32 @@ func registerRESTAPIsRoutes(api fiber.Router, db database.Service) {
 	// This is one of the reasons why I like Go. For example, when I'm lazy to implement something from scratch,
 	// I can just use a package that is already stable then build on top of it using higher-order functions.
 	redirectMiddleware := NewRedirectMiddleware(
+		// Note: This is a tip for manipulating bot scanners that attempt to access sensitive directories like credentials or configs.
+		// For example, if http://api.localhost:8080/v1/server/health/db is a registered endpoint, when a request is made to http://api.localhost:8080/v1/server/health/,
+		// it will be redirected to http://api.localhost:8080/.
 		WithRedirectRules(map[string]string{
-			"v1": "/",
+			"v1":                "/",
+			"v1/server/health":  "/",
+			"v1/server/health/": "/",
 		}),
 		WithRedirectStatusCode(fiber.StatusMovedPermanently),
 	)
 
-	rootGroup.Routes = append(rootGroup.Routes, APIRoute{
-		Path:    "v*",
-		Method:  fiber.MethodGet,
-		Handler: redirectMiddleware,
-	})
+	methods := []string{
+		fiber.MethodGet,
+		fiber.MethodPost,
+		fiber.MethodPut,
+		fiber.MethodDelete,
+		fiber.MethodPatch,
+	}
+
+	for _, method := range methods {
+		rootGroup.Routes = append(rootGroup.Routes, APIRoute{
+			Path:    "*",
+			Method:  method,
+			Handler: redirectMiddleware,
+		})
+	}
 
 	// Register the root group
 	registerGroup(api, rootGroup)

--- a/backend/internal/middleware/restapis_routes.go
+++ b/backend/internal/middleware/restapis_routes.go
@@ -123,11 +123,15 @@ func registerRESTAPIsRoutes(api fiber.Router, db database.Service) {
 	)
 
 	methods := []string{
+		fiber.MethodHead,
 		fiber.MethodGet,
 		fiber.MethodPost,
 		fiber.MethodPut,
 		fiber.MethodDelete,
 		fiber.MethodPatch,
+		fiber.MethodConnect,
+		fiber.MethodOptions,
+		fiber.MethodTrace,
 	}
 
 	for _, method := range methods {


### PR DESCRIPTION
- [+] feat(restapis_routes): add redirect rules for health check endpoints

Note: This commit enhances the redirect middleware by adding redirect rules for health check endpoints. If a request is made to `/v1/server/health` or `/v1/server/health/`, it will be redirected to the root `/` endpoint. This is a technique to manipulate bot scanners attempting to access sensitive directories. Additionally, the redirect middleware is now applied to all HTTP methods (GET, POST, PUT, DELETE, PATCH) for the `*` path pattern, ensuring comprehensive coverage of potential scanner requests.