### PR TITLE
Implement [Middleware] [Helper Function] "CustomNextStatusCode"

### DIFF
--- a/backend/internal/middleware/helper.go
+++ b/backend/internal/middleware/helper.go
@@ -1122,3 +1122,34 @@ func WithCompressNext(next func(*fiber.Ctx) bool) func(*compress.Config) {
 		config.Next = next
 	}
 }
+
+// CustomNextStatusCode is a helper function that creates a custom Next function for the fiber middleware.
+//
+// The returned Next function checks the HTTP status code of the response and determines whether to skip
+// the middleware based on the provided status codes. If the response status code matches any of the
+// specified status codes, the Next function returns true, indicating that the middleware should be skipped.
+//
+// Example usage:
+//
+//	// Create a custom skipper function to skip the middleware for 404 and 500 status codes
+//	redirectSkipper := CustomNextStatusCode(fiber.StatusMovedPermanently)
+//
+// Parameters:
+//   - statusCodes: Variadic int parameters representing the HTTP status codes to skip the middleware for.
+//
+// Returns:
+//   - A function that takes a [fiber.Ctx] as input and returns a boolean value indicating whether to
+//     skip the middleware for the given request based on the response status code.
+//
+// Note: This function is suitable for redirect or error handling middleware or middleware that should be skipped for certain status codes.
+func CustomNextStatusCode(statusCodes ...int) func(*fiber.Ctx) bool {
+	return func(c *fiber.Ctx) bool {
+		status := c.Response().StatusCode()
+		for _, code := range statusCodes {
+			if status == code {
+				return true
+			}
+		}
+		return false
+	}
+}


### PR DESCRIPTION
- [+] feat(middleware): add CustomNextStatusCode helper function

Note: The CustomNextStatusCode helper function creates a custom Next function for the Fiber middleware. It checks the HTTP status code of the response and determines whether to skip the middleware based on the provided status codes. If the response status code matches any of the specified status codes, the Next function returns true, indicating that the middleware should be skipped.

- [+] feat(routes): add status code skipper for cache middleware
- [+] Add a status code skipper using the CustomNextStatusCode helper function to skip the cache middleware for specific status codes. In this case, the cache middleware will be skipped for the 301 (Moved Permanently) status code.
- [+] refactor(routes): use CustomNextStack for cache middleware skipper
- [+] Refactor the cache middleware skipper to use the CustomNextStack function, which allows combining multiple skipper functions. The contentTypeSkip and statusCodeSkip functions are passed as a map to the CustomNextStack function to create a combined skipper for the cache middleware.