### PR TITLE
Docs [Router] [Config] [Example Skip Cache Middleware] Update Comments

### DIFF
--- a/backend/internal/middleware/routes.go
+++ b/backend/internal/middleware/routes.go
@@ -133,8 +133,8 @@ func registerRouteConfigMiddleware(app *fiber.App, db database.Service) {
 		mime.TextEventStream,
 		// This is temporary because it only registers 2 routers (currently).
 		// When there are 3 or more routers, it will be structured like this in the demo:
-		// - https://btz.pm (frontend currently disabled because I don't have any ideas for building the front-end, so it will return to the wildcard (see fiber.NewError in DomainRouter))
-		// - https://api-beta.btz.pm (REST APIs)
+		// - TLSv1.3 & HTTP/3 (QUIC): https://btz.pm (frontend currently disabled because I don't have any ideas for building the front-end, so it will return to the wildcard (see fiber.NewError in DomainRouter))
+		// - TLSv1.3 & mTLSv1.3: https://api-beta.btz.pm (REST APIs)
 		fiber.MIMETextPlain,
 		fiber.MIMETextPlainCharsetUTF8,
 	)


### PR DESCRIPTION
- [+] refactor(middleware): update comments for route configuration middleware

Note: The comments in the `registerRouteConfigMiddleware` function were updated to provide more details about the future structure of the routers and the protocols they will use. The comments now mention that the frontend will use TLSv1.3 & HTTP/3 (QUIC), while the REST APIs will use TLSv1.3 & mTLSv1.3.