### PR TITLE
Feat [Crypto] [Web3] [ETH] Add Next (SKIP) Function

### DIFF
--- a/backend/internal/middleware/authentication/crypto/web3/eth/docs.go
+++ b/backend/internal/middleware/authentication/crypto/web3/eth/docs.go
@@ -16,6 +16,7 @@
 //		URL         string
 //		ContextKey  any
 //		ErrorHandler func(c *fiber.Ctx, err error) error
+//		Next         func(*fiber.Ctx) bool
 //	}
 //
 // Configuration:
@@ -23,6 +24,10 @@
 //   - ContextKey: The key used to store the Ethereum client in the Fiber context. This key must be specified when creating the Config struct.
 //   - ErrorHandler: A custom error handler function to handle errors that occur during client creation.
 //     If not provided, it defaults to using htmx.NewStaticHandleVersionedAPIError.
+//   - Next: A function that determines whether to skip the middleware and proceed to the next middleware or route handler.
+//     It takes a Fiber context as input and returns a boolean value.
+//     If true, the middleware is skipped, and the next middleware or route handler is executed.
+//     If false, the middleware continues its execution.
 //
 // Retrieving the Ethereum Client:
 //

--- a/backend/internal/middleware/authentication/crypto/web3/eth/new.go
+++ b/backend/internal/middleware/authentication/crypto/web3/eth/new.go
@@ -19,13 +19,19 @@ type Config struct {
 	URL          string
 	ContextKey   any
 	ErrorHandler func(c *fiber.Ctx, err error) error
+	Next         func(*fiber.Ctx) bool
 }
 
 // New is a custom Fiber middleware that configures the Ethereum client
 //
-// Note: It should be fine if gateway via cloudflare
+// Note: It should be fine if the gateway is via Cloudflare. This is how we test for excellent performance - by doing one thing and doing it well.
 func New(config Config) fiber.Handler {
 	return func(c *fiber.Ctx) error {
+		// Check if the request should be skipped
+		if config.Next != nil && config.Next(c) {
+			return c.Next()
+		}
+
 		// Create a new Ethereum client using the provided URL
 		client, err := ethclient.Dial(config.URL)
 		if err != nil {


### PR DESCRIPTION
- [+] feat(eth): add Next function to Config for skipping middleware

Note: This feature allows flexibility in controlling when the Ethereum middleware should be applied based on custom conditions defined in the `Next` function.