### PR TITLE
Implement [Middleware] [Helper Function] Another QUIC

### DIFF
--- a/backend/internal/middleware/helper.go
+++ b/backend/internal/middleware/helper.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gofiber/fiber/v2/middleware/compress"
 	"github.com/gofiber/fiber/v2/middleware/cors"
 	"github.com/gofiber/fiber/v2/middleware/csrf"
+	"github.com/gofiber/fiber/v2/middleware/earlydata"
 	"github.com/gofiber/fiber/v2/middleware/encryptcookie"
 	"github.com/gofiber/fiber/v2/middleware/etag"
 	"github.com/gofiber/fiber/v2/middleware/favicon"
@@ -1151,5 +1152,33 @@ func CustomNextStatusCode(statusCodes ...int) func(*fiber.Ctx) bool {
 			}
 		}
 		return false
+	}
+}
+
+// WithEarlyDataNext is an option function for NewEarlyData (Another QUIC) that sets the Next function.
+func WithEarlyDataNext(next func(c *fiber.Ctx) bool) func(*earlydata.Config) {
+	return func(config *earlydata.Config) {
+		config.Next = next
+	}
+}
+
+// WithIsEarlyData is an option function for NewEarlyData (Another QUIC) that sets the IsEarlyData function.
+func WithIsEarlyData(isEarlyData func(c *fiber.Ctx) bool) func(*earlydata.Config) {
+	return func(config *earlydata.Config) {
+		config.IsEarlyData = isEarlyData
+	}
+}
+
+// WithAllowEarlyData is an option function for NewEarlyData (Another QUIC) that sets the AllowEarlyData function.
+func WithAllowEarlyData(allowEarlyData func(c *fiber.Ctx) bool) func(*earlydata.Config) {
+	return func(config *earlydata.Config) {
+		config.AllowEarlyData = allowEarlyData
+	}
+}
+
+// WithEarlyDataError is an option function for NewEarlyData (Another QUIC) that sets the Error value.
+func WithEarlyDataError(err error) func(*earlydata.Config) {
+	return func(config *earlydata.Config) {
+		config.Error = err
 	}
 }

--- a/backend/internal/middleware/utils.go
+++ b/backend/internal/middleware/utils.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gofiber/fiber/v2/middleware/compress"
 	"github.com/gofiber/fiber/v2/middleware/cors"
 	"github.com/gofiber/fiber/v2/middleware/csrf"
+	"github.com/gofiber/fiber/v2/middleware/earlydata"
 	"github.com/gofiber/fiber/v2/middleware/encryptcookie"
 	"github.com/gofiber/fiber/v2/middleware/etag"
 	"github.com/gofiber/fiber/v2/middleware/favicon"
@@ -812,4 +813,26 @@ func NewResponseTime(options ...any) fiber.Handler {
 
 	// Return the response time middleware.
 	return restimeMiddleware
+}
+
+// NewEarlyData (Another QUIC) creates a new early data middleware with optional custom configuration options.
+//
+// Note: Consider carefully when using an external load balancer/ingress (e.g., nginx) due to Fiber's built-in support for
+// Another QUIC, which is already safe and requires explicit TLSv1.3 for the external load balancer/ingress.
+func NewEarlyData(options ...any) fiber.Handler {
+	// Create a new early data configuration.
+	config := earlydata.Config{}
+
+	// Apply any additional options to the early data configuration.
+	for _, option := range options {
+		if optFunc, ok := option.(func(*earlydata.Config)); ok {
+			optFunc(&config)
+		}
+	}
+
+	// Create the early data middleware with the configured options.
+	earlyDataMiddleware := earlydata.New(config)
+
+	// Return the early data middleware.
+	return earlyDataMiddleware
 }


### PR DESCRIPTION
- [+] feat(middleware): add support for early data (Another QUIC) middleware
- [+] add `WithEarlyDataNext`, `WithIsEarlyData`, `WithAllowEarlyData`, and `WithEarlyDataError` option functions for configuring the early data middleware
- [+] implement `NewEarlyData` function to create a new early data middleware with optional custom configuration options