### PR TITLE
Feat [pkg] [MIME] PrometheusMetrics MIME type

### DIFF
--- a/backend/internal/middleware/routes.go
+++ b/backend/internal/middleware/routes.go
@@ -140,6 +140,9 @@ func registerRouteConfigMiddleware(app *fiber.App, db database.Service) {
 		// to do one thing and do it well in the same host and repository is uncommon; however, it is secure.
 		fiber.MIMETextPlain,
 		fiber.MIMETextPlainCharsetUTF8,
+		// Note: It's important to disable caching for this MIME type, which is particularly suitable when using Grafana,
+		// especially when playing HTMX MinesweeperX through Grafana plugins while monitoring.
+		mime.PrometheusMetrics,
 	)
 	// Note: It's important to skip caching for redirect status codes, which can enhance security (e.g., for auth mechanisms).
 	// If redirect status codes are cached, it can lead to security issues (e.g., new CVEs, exploits such as cache poisoning) because when redirect status codes are cached (hit),

--- a/backend/pkg/mime/mime.go
+++ b/backend/pkg/mime/mime.go
@@ -54,3 +54,21 @@ const (
 	// compression for ICO files when using the CompressMiddleware (brotli).
 	ImageXIcon = "image/x-icon"
 )
+
+const (
+	// PrometheusMetrics represents the MIME type for Prometheus metrics.
+	//
+	// It is used to indicate that the response body contains Prometheus-formatted metrics data.
+	// Prometheus is a popular open-source monitoring and alerting system that collects and stores
+	// metrics as time series data.
+	//
+	// The MIME type follows the format "text/plain; version=0.0.4; charset=utf-8; escaping=values":
+	// 	- "text/plain" indicates that the content is plain text.
+	// 	- "version=0.0.4" specifies the version of the Prometheus text format.
+	// 	- "charset=utf-8" indicates that the character encoding is UTF-8.
+	// 	- "escaping=values" specifies that the metric values are escaped according to Prometheus conventions.
+	//
+	// When exposing Prometheus metrics, the server should set the "Content-Type" header to this MIME type.
+	// Prometheus servers and clients use this MIME type to identify and parse the metrics data correctly.
+	PrometheusMetrics = "text/plain; version=0.0.4; charset=utf-8; escaping=values"
+)


### PR DESCRIPTION
- [+] feat(middleware): add PrometheusMetrics MIME type to skipCachingMIMETypes
- [+] feat(mime): introduce PrometheusMetrics MIME type

Note: This commit introduces a new MIME type constant called PrometheusMetrics in the mime package. It represents the MIME type for Prometheus metrics, which is used to indicate that the response body contains Prometheus-formatted metrics data. The MIME type follows the format "text/plain; version=0.0.4; charset=utf-8; escaping=values" and provides details about the content type, version, character encoding, and escaping conventions. When exposing Prometheus metrics, the server should set the "Content-Type" header to this MIME type to ensure correct identification and parsing of the metrics data by Prometheus servers and clients.