### PR TITLE
Feat [K8S] prometheus rules for recording metrics

### DIFF
--- a/k8s-deployment/prometheus_portable_rules_record.yaml
+++ b/k8s-deployment/prometheus_portable_rules_record.yaml
@@ -1,0 +1,48 @@
+# Prometheus REST APIs [Zer0-Downtime] record rules.
+#
+# Note: This should optimize memory usage because Prometheus consumes a lot of memory when there are millions ~ billions of requests.
+# See https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/
+# 🙈 If you don't know what you are doing, don't do anything here :)
+
+groups:
+  - name: record.rules
+    rules:
+      - record: job:up:avg
+        expr: avg by (job) (up)
+        labels:
+          severity: page
+
+      - record: job:up:sum
+        expr: sum by (job) (up)
+        labels:
+          severity: page
+
+      - record: instance:up:avg
+        expr: avg by (instance) (up)
+        labels:
+          severity: page
+
+      - record: instance:up:sum
+        expr: sum by (instance) (up)
+        labels:
+          severity: page
+
+      - record: job:restapis_http_requests_total:rate5m # change the "restapis_http_requests_total"
+        expr: sum by (job) (rate(restapis_http_requests_total[5m]))
+        labels:
+          severity: page
+
+      - record: job:restapis_http_requests_total:rate1m # change the "restapis_http_requests_total"
+        expr: sum by (job) (rate(restapis_http_requests_total[1m]))
+        labels:
+          severity: page
+
+      - record: instance:restapis_http_requests_total:rate5m # change the "restapis_http_requests_total"
+        expr: sum by (instance) (rate(restapis_http_requests_total[5m]))
+        labels:
+          severity: page
+
+      - record: instance:restapis_http_requests_total:rate1m # change the "restapis_http_requests_total"
+        expr: sum by (instance) (rate(restapis_http_requests_total[1m]))
+        labels:
+          severity: page


### PR DESCRIPTION
- [+] feat(prometheus): add portable rules for recording metrics

- [+]  Add Prometheus recording rules to optimize memory usage when there are millions of requests. The rules include:
- [+]  job:up:avg and job:up:sum to record the average and sum of the 'up' metric by job
- [+]  instance:up:avg and instance:up:sum to record the average and sum of the 'up' metric by instance
- [+]  job:restapis_http_requests_total:rate5m and job:restapis_http_requests_total:rate1m to record the rate of 'restapis_http_requests_total' metric over 5m and 1m intervals by job
- [+]  instance:restapis_http_requests_total:rate5m and instance:restapis_http_requests_total:rate1m to record the rate of 'restapis_http_requests_total' metric over 5m and 1m intervals by instance