### PR TITLE
Feat [K8S] VPA configuration for MySQL deployment

### DIFF
--- a/k8s-deployment/mysql_vpa.yaml
+++ b/k8s-deployment/mysql_vpa.yaml
@@ -1,0 +1,26 @@
+# REST APIs MySQL VPA Configuration [Zer0 Downtime]
+# Important: When deploying MySQL in Kubernetes, it's recommended to use VPA (Vertical Pod Autoscaler) instead of HPA (Horizontal Pod Autoscaler).
+# MySQL is primarily bound by memory and disk resources, so if using Kubernetes with manual or retain PersistentVolumes, HPA can be used.
+# However, if manual or retain PersistentVolumes are not allowed (e.g., due to an existing driver or other restrictions), then VPA is the recommended approach.
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: mysql-vpa # Change this to a descriptive name for the MySQL VPA
+  namespace: database # Change this to the namespace where the MySQL deployment is located
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: mysql
+  updatePolicy:
+    updateMode: "Auto"
+  resourcePolicy:
+    containerPolicies:
+      - containerName: "*"
+        minAllowed:
+          cpu: 100m
+          memory: 100Mi
+        maxAllowed:
+          cpu: 2
+          memory: 2Gi
+        controlledResources: ["cpu", "memory"]


### PR DESCRIPTION
- [+] feat(mysql_vpa.yaml): add VPA configuration for MySQL deployment in Kubernetes
- [+] set targetRef to MySQL deployment
- [+] configure updatePolicy to Auto mode
- [+] define resourcePolicy with min and max allowed resources for containers
- [+] specify cpu and memory as controlled resources