### PR TITLE
Refactor [Worker] use defer with anonymous function

### DIFF
--- a/worker/do_work.go
+++ b/worker/do_work.go
@@ -141,8 +141,10 @@ func (wp *Pool[T]) Start() {
 	// Note: this used std logger, due it not possible import internal package in the backend to outside (not allowed).
 	log.Print("Worker pool started.")
 	go func() {
-		defer atomic.StoreUint32(&wp.isRunning, 0)
-		defer log.Print("Worker pool exiting.")
+		defer func() {
+			atomic.StoreUint32(&wp.isRunning, 0)
+			log.Print("Worker pool exiting.")
+		}()
 
 		// Use the WaitGroup to wait for workers to start
 		wp.wg.Add(wp.numWorkers)

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -31,6 +31,10 @@ func (j *MockJob[T]) Execute(ctx context.Context) (T, error) {
 	return j.result, j.err
 }
 
+const (
+	defaultSleepTime = 1 * time.Second
+)
+
 func TestPool_Submit(t *testing.T) {
 	pool := worker.NewDoWork[string]()
 
@@ -124,7 +128,7 @@ func TestPool_WorkerLoop(t *testing.T) {
 	pool.Stop()
 
 	// Wait for the worker loop to exit (this might be necessary depending on your test setup)
-	time.Sleep(worker.DefaultWorkerSleepTime)
+	time.Sleep(defaultSleepTime)
 }
 
 func TestPool_StartStopLoopZ(t *testing.T) {
@@ -133,7 +137,7 @@ func TestPool_StartStopLoopZ(t *testing.T) {
 		worker.WithJobChannelOptions(worker.WithChanBuffer[worker.Job[string]](1)),
 		worker.WithResultChannelOptions(worker.WithChanBuffer[string](1)),
 		worker.WithErrorChannelOptions[string](worker.WithChanBuffer[error](1)),
-		worker.WithIdleCheckInterval[string](worker.DefaultWorkerSleepTime),
+		worker.WithIdleCheckInterval[string](defaultSleepTime),
 	)
 
 	// Register a test job that takes some time to execute
@@ -159,7 +163,7 @@ func TestPool_StartStopLoopZ(t *testing.T) {
 	pool.Stop()
 
 	// Wait for the worker loop to exit.
-	time.Sleep(worker.DefaultWorkerSleepTime)
+	time.Sleep(defaultSleepTime)
 
 	// Verify that the pool is stopped
 	if pool.IsRunning() {


### PR DESCRIPTION
- [+] refactor(do_work.go): use defer with anonymous function to group multiple deferred statements
- [+] refactor(worker_test.go): extract default sleep time to a constant
- [+] refactor(worker_test.go): replace usage of worker.DefaultWorkerSleepTime with defaultSleepTime constant