### PR TITLE
Upgrade Golang Version to Latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # Note: This is a boilerplate for Docker regarding this repository.
 # Also, note that the "# Copy the source code." or other "# Copy ..." comments need to be written specifically for your use case,
 # for example, copying a directory of the source code for building a container.
-FROM golang:1.23.0 AS builder
+FROM golang:1.23.1 AS builder
 
 # Set the working directory outside $GOPATH to enable the support for modules.
 WORKDIR /app

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module h0llyw00dz-template
 
-go 1.23.0
+go 1.23.1
 
 require (
 	github.com/H0llyW00dzZ/FiberValidator v0.5.2


### PR DESCRIPTION
- [+] chore: upgrade golang version from 1.23.0 to 1.23.1 in Dockerfile and go.mod

Note: This is still sailing smoothly ⛵ with Kubernetes ☸, especially when combined with workers (as long as metrics are not directly bound to the repository, such as Heroku Go Metrics/Prometheus Middleware aka proms portable). It can handle billions of requests as well.