### PR TITLE
Enhance [K8S] Deployment Template

### DIFF
--- a/k8s-deployment/restapis-deploy.yaml
+++ b/k8s-deployment/restapis-deploy.yaml
@@ -184,6 +184,11 @@ spec:
     - protocol: TCP
       port: 80
       targetPort: 8080
+  # Note: The timeoutSeconds can be customized, which is a good choice for QoS: Burstable pods that handle concurrency and maintain session affinity
+  sessionAffinity: ClientIP
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 10800
 ---
 # Note: This HPA is designed for microservices that consume vCPU.
 # This boilerplate primarily consumes vCPU (combined with a worker) and bandwidth to handle high traffic (e.g., network load)


### PR DESCRIPTION
- [+] feat(k8s-deployment): add sessionAffinity to restapis-deploy.yaml with ClientIP and timeoutSeconds configuration