### PR TITLE
Docs [Worker] Clarify Metrics

### DIFF
--- a/worker/docs.go
+++ b/worker/docs.go
@@ -80,6 +80,6 @@
 //   - When the GC (Garbage Collector) becomes overloaded (overhead), it will take a lot of time to free memory resources.
 //
 // For example, here's how metrics can be wrongly implemented:
-//   - Metrics should not be stored in memory and then wait for collection, because when waiting for collection, the garbage collector will become overhead as goroutines hold the metrics
+//   - Metrics should not be stored in memory and then wait for collection, because when store in memory then waiting for collection, the garbage collector will become overhead as goroutines hold the metrics
 //     that must be collected by an external process, caller, or whatever it is.
 package worker


### PR DESCRIPTION
- [+] docs(worker): clarify that metrics should not be stored in memory before collection to avoid GC overhead