### PR TITLE
Chore [K8S] [Ingress Nginx] REST APIs Service

### DIFF
--- a/k8s-deployment/rest-apis-ingress-nginx.yaml
+++ b/k8s-deployment/rest-apis-ingress-nginx.yaml
@@ -32,7 +32,7 @@ kind: Ingress
 metadata:
   name: rest-api-ingress # change this
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    # kubernetes.io/ingress.class: "nginx" # deprecated
     # nginx.ingress.kubernetes.io/ssl-passthrough: "true"  # Removed
     nginx.ingress.kubernetes.io/ssl-certificate: "localhost-tls" # change this
     nginx.ingress.kubernetes.io/ssl-certificate-key: "localhost-tls" # change this


### PR DESCRIPTION
- [+] chore(k8s-deployment): comment out deprecated 'kubernetes.io/ingress.class' annotation in rest-apis-ingress-nginx.yaml