### PR TITLE
Docs [K8S Deployment] [MySQL] clarify data safety from Loss

### DIFF
--- a/k8s-deployment/MySQL.md
+++ b/k8s-deployment/MySQL.md
@@ -38,8 +38,8 @@ To deploy the MySQL service using the provided K8s deployment files, follow thes
    Update the `mysql-storage.yaml` file with your desired storage configuration (e.g., size, storage class).
 
 > [!NOTE]
-> When storage is `fully encrypted` with the flexibility to be `attached/detached` by the cluster and is bound to the deployment along with VPA, 
-> the `MySQL data` in the pods will be safe and secure from loss when pods are restarting (e.g., `restarting 9999999 times`) or other events occur. This is because all `MySQL data` is bound to the disk.
+> When storage is `fully encrypted` with the flexibility to be `attached/detached` by the cluster and is bound to the deployment along with VPA,
+> the `MySQL data` in the pods will be safe and secure from data loss when pods are restarting (e.g., `restarting 9999999 times`) or other events occur (e.g., `node scaling down from 999999999999 nodes with high specifications (e.g., 999999999999vCPU, 999999999999 Memory Terabyte) to a single node with lower specifications by the autopilot/cluster autoscaler`). This is because all `MySQL data` is bound to the disk.
 > Also note that it is not recommended to deploy MySQL along with HPA while using storage that is fully encrypted with the flexibility to be attached/detached.
 > This is because the pods will remain in a pending state due to storage limitations, as typically only one pod can access the storage at a time. Even if the storage supports multiple pods (sharing), it is usually limited to a few pods (e.g., `5 pods`).
 


### PR DESCRIPTION
- [+] docs(MySQL.md): clarify data safety and security with encrypted storage and VPA
- [+] docs(MySQL.md): provide examples of pod restarts and node scaling scenarios
- [+] docs(MySQL.md): add note about not recommending MySQL deployment with HPA and encrypted storage