### PR TITLE
Enhance [K8S Deploy] [MySQL ConfigMap] SSL/TLS CA Path for ECC

### DIFF
--- a/k8s-deployment/mysql-deploy.yaml
+++ b/k8s-deployment/mysql-deploy.yaml
@@ -20,6 +20,7 @@ data:
     ssl-cert=/etc/mysql/tls/certificate.cer
     ssl-key=/etc/mysql/tls/server-key.pem
     ssl-ca=/etc/mysql/tls/ECC.crt
+    ssl-capath=/etc/mysql/tls
     require_secure_transport=ON
     tls-version=TLSv1.3
     pid-file=/var/run/mysqld/mysqld.pid


### PR DESCRIPTION
- [+] feat(mysql-deploy.yaml): add ssl-capath for ECC configuration to mysql-args.conf