### PR TITLE
Docs [Proxy/Standalone LB] Update Documentation

### DIFF
--- a/backend/internal/middleware/helper.go
+++ b/backend/internal/middleware/helper.go
@@ -1132,9 +1132,10 @@ func WithProxyingWriteBufferSize(size int) func(*proxy.Config) {
 // WithProxyingTLSConfig is an option function for NewProxying that sets the TLS configuration.
 //
 // Note: For private CAs/public CAs, it is recommended to use a certificate with X509v3 Extended Key Usage
-// for TLS Web Server Authentication and TLS Web Client Authentication. To make it faster,
-// use ECC (Elliptic Curve Cryptography) instead of RSA, as it can save bandwidth costs.
-// If bandwidth is free because this proxying is only used for internal mode, then RSA can be used.
+// for TLS Web Server Authentication (OID.1.3.6.1.5.5.7.3.1) and TLS Web Client Authentication (OID.1.3.6.1.5.5.7.3.2),
+// both of which are defined in RFC 5280. To make it faster, use ECC (Elliptic Curve Cryptography)
+// instead of RSA, as it can save bandwidth costs. If bandwidth is free because this proxying is only used
+// for internal mode, then RSA can be used.
 func WithProxyingTLSConfig(tlsConfig *tls.Config) func(*proxy.Config) {
 	return func(config *proxy.Config) {
 		config.TlsConfig = tlsConfig


### PR DESCRIPTION
- [+] docs(helper.go): update comments in WithProxyingTLSConfig function to include OID and RFC 5280 references