### PR TITLE
Enhance [K8S Deploy] [REST APIs] Deployment Template

### DIFF
--- a/k8s-deployment/restapis-deploy.yaml
+++ b/k8s-deployment/restapis-deploy.yaml
@@ -1,5 +1,8 @@
 # REST APIs Deployment [Zer0 Downtime] by H0llyW00dzZ for an microservices k8s.
 #
+# Important: While this deployment is "Stateless" and 100% stable with HPA and CA (Autopilot),
+# don't switch to "Stateful" unless you are using Fiber's in-memory storage (see https://docs.gofiber.io/storage/memory_v2.x.x/memory/).
+#
 # Note: This will automatically create the namespace if it doesn't exist. If the namespace already exists, it won't be affected.
 apiVersion: v1
 kind: Namespace
@@ -44,7 +47,8 @@ spec:
           resources:
             requests:
               memory: "256Mi"
-              cpu: "250m"
+              # This is suitable for Cluster Autoscaler (Auto Pilot) and GKE Autopilot that use nodes with low average specs (e.g., 4 vCPU, 2 vCPU)
+              cpu: "350m"
             limits:
               memory: "512Mi"
               cpu: "500m"
@@ -235,6 +239,7 @@ spec:
         target:
           type: Utilization
           averageUtilization: 80
+    # TODO: Remove this because Fiber has built-in zero-allocation?
     - type: Resource
       resource:
         name: memory


### PR DESCRIPTION
- [+] chore(k8s-deployment/restapis-deploy.yaml): add note about stateless deployment stability with HPA and CA
- [+] docs(k8s-deployment/restapis-deploy.yaml): add link to Fiber's in-memory storage documentation for stateful deployments
- [+] chore(k8s-deployment/restapis-deploy.yaml): increase CPU request to 350m for suitability with Cluster Autoscaler and GKE Autopilot
- [+] chore(k8s-deployment/restapis-deploy.yaml): add TODO to remove memory resource from HPA due to Fiber's zero-allocation