### PR TITLE
Docs [K8S Deploy] [REST APIs] Update Documentation

### DIFF
--- a/k8s-deployment/restapis-deploy.yaml
+++ b/k8s-deployment/restapis-deploy.yaml
@@ -49,7 +49,11 @@ spec:
           resources:
             requests:
               memory: "256Mi"
-              # This is suitable for Cluster Autoscaler (Auto Pilot) and GKE Autopilot that use nodes with low average specs (e.g., 4 vCPU, 2 vCPU)
+              # This is suitable for Cluster Autoscaler (Autopilot) or GKE Autopilot that use nodes with low average specs (e.g., 4 vCPU, 2 vCPU).
+              # For example, when the CPU reaches 350m or 500m due to concurrency (e.g., the goroutine workers), the HPA replica count will be around 4 or more.
+              # If the replica count reaches 5 or higher, it will cause pending pods, and the Cluster Autoscaler (Autopilot) or GKE Autopilot will attach another node until there are no pending pods.
+              # Later, each node (e.g., 5 nodes) will have a CPU under 80%.
+              # Also note that this example demonstrates how to handle unpredictable and dynamic resource usage, as it is difficult to predict resource usage accurately, even if you are a genius.
               cpu: "350m"
             limits:
               memory: "512Mi"


### PR DESCRIPTION
- [+] chore(restapis-deploy.yaml): add comments explaining the CPU request value and its effect on HPA and Cluster Autoscaler behavior