### PR TITLE
Revert "Enhance Content Security Policy Generator (#1006)"

### DIFF
--- a/backend/internal/middleware/csp/new.go
+++ b/backend/internal/middleware/csp/new.go
@@ -63,11 +63,9 @@ func New(config ...Config) fiber.Handler {
 		// When using base64 encoding, consider storing the base64 encoded in c.Locals first or somewhere (e.g, database). Avoid fetching the value from
 		// the header and then putting it in the render or direct in the render, as the format will be different due to sanitization.
 		cspValue := cfg.CSPValueGenerator(randomness, customValues)
-		copyCSPValue := unique.Make(cspValue)
 
-		// Set CSP
-		// Now this immutable forever
-		c.Set("Content-Security-Policy", copyCSPValue.Value())
+		// Set CSP header
+		c.Set("Content-Security-Policy", cspValue)
 
 		// Continue to next middleware
 		return c.Next()


### PR DESCRIPTION
This reverts commit fb92a0414ed6af90b1259952cc2a4a14af28d4d8.

Reason: Using a cryptographically can be problematic when generating unique values, especially if the generated values (e.g., ciphertexts represented as hex strings).