### PR TITLE
Improve [MySQL] [Helper Function] Backup Mechanism

### DIFF
--- a/backend/internal/database/backup.go
+++ b/backend/internal/database/backup.go
@@ -197,7 +197,14 @@ func (s *service) dumpTableData(ctx context.Context, file *os.File, tableName st
 func buildInsertStatement(tableName string, columns []string, values []any) string {
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("INSERT INTO `%s` (", tableName))
-	sb.WriteString(strings.Join(columns, ", "))
+	// This is now correct and can be imported via phpMyAdmin as well.
+	for i, column := range columns {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(fmt.Sprintf("`%s`", column))
+	}
+
 	sb.WriteString(") VALUES (")
 
 	for i, val := range values {
@@ -209,7 +216,7 @@ func buildInsertStatement(tableName string, columns []string, values []any) stri
 		} else if b, ok := val.([]byte); ok {
 			sb.WriteString(fmt.Sprintf("'%s'", escapeString(string(b))))
 		} else {
-			sb.WriteString(fmt.Sprintf("'%v'", escapeString(fmt.Sprintf("%v", val))))
+			sb.WriteString(fmt.Sprintf("'%s'", escapeString(fmt.Sprintf("%v", val))))
 		}
 	}
 	sb.WriteString(");\n")

--- a/backend/internal/database/helper.go
+++ b/backend/internal/database/helper.go
@@ -102,6 +102,12 @@ func IsValidTableName(name string) bool {
 }
 
 // escapeString safely escapes special characters in strings.
+//
+// This is now correct and can be imported via phpMyAdmin as well.
 func escapeString(value string) string {
-	return strings.ReplaceAll(strings.ReplaceAll(value, "'", "''"), "\\", "\\\\")
+	value = strings.ReplaceAll(value, "'", "''")
+	value = strings.ReplaceAll(value, "\\", "\\\\")
+	value = strings.ReplaceAll(value, "\n", "\\n")
+	value = strings.ReplaceAll(value, "\"", "\\\"")
+	return value
 }


### PR DESCRIPTION
- [+] fix(database): improve string escaping and column formatting in SQL dump
- [+] refactor(database/backup.go): enhance buildInsertStatement to correctly format column names
- [+] fix(database/backup.go): adjust string formatting for non-string values
- [+] fix(database/helper.go): extend escapeString function to handle newlines and double quotes