### PR TITLE
Update Docs [Crypto] [GPG/OpenPGP] [Helper Function] Streaming Encryption Testing

### DIFF
--- a/backend/internal/middleware/authentication/crypto/gpg/encrypt_test.go
+++ b/backend/internal/middleware/authentication/crypto/gpg/encrypt_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-// Sample PGP/GPG keys for testing
+// Sample PGP/GPG keys for testing (RFC 9580) Sections 12.7, 5.2.3.4, and 11.5 Latest strong mechanisms for GPG/OpenPGP.
 //
 // KEY:
 //


### PR DESCRIPTION
- [+] docs(encrypt_test.go): update comment to reference RFC 9580 sections for sample PGP/GPG keys