### PR TITLE
Improve [Crypto] [GPG/OpenPGP] [Helper Function] Streaming Encryption

### DIFF
--- a/backend/internal/database/backup.go
+++ b/backend/internal/database/backup.go
@@ -113,7 +113,7 @@ func (s *service) BackupTablesConcurrently(tablesToBackup []string) error {
 }
 
 // BackupTablesWithGPG creates a backup of specified tables in the database and encrypts it using a PGP public key.
-func (s *service) BackupTablesWithGPG(tablesToBackup []string, publicKey string) error {
+func (s *service) BackupTablesWithGPG(tablesToBackup []string, publicKey []string) error {
 	for _, tableName := range tablesToBackup {
 		if !IsValidTableName(tableName) {
 			return fmt.Errorf("invalid table name: %s", tableName)

--- a/backend/internal/database/mysql_redis.go
+++ b/backend/internal/database/mysql_redis.go
@@ -212,7 +212,7 @@ type Service interface {
 	// 	- Key ID: AB68BB42A56C9894
 	// 	- Public Key Algo: ECDH
 	// 	- Status: Success
-	BackupTablesWithGPG(tablesToBackup []string, publicGPGKey string) error
+	BackupTablesWithGPG(tablesToBackup []string, publicGPGKey []string) error
 }
 
 // service is a concrete implementation of the Service interface.

--- a/backend/internal/middleware/authentication/crypto/gpg/encrypt.go
+++ b/backend/internal/middleware/authentication/crypto/gpg/encrypt.go
@@ -70,7 +70,7 @@ func (e *Encryptor) EncryptFile(inputFile, outputFile string) error {
 
 // EncryptStream encrypts data from an input stream and writes to an output stream using the Encryptor's public key.
 //
-// TODO: Improve this
+// TODO: Improve this. It should be an object that can be stored (e.g., in a database or storage mechanism) for compatibility with HPA in Kubernetes.
 func (e *Encryptor) EncryptStream(input io.Reader, output io.Writer) error {
 	// Create a key ring from the public key
 	keyRing, err := e.createKeyRing()

--- a/backend/internal/middleware/authentication/crypto/gpg/encrypt.go
+++ b/backend/internal/middleware/authentication/crypto/gpg/encrypt.go
@@ -71,6 +71,7 @@ func (e *Encryptor) EncryptFile(inputFile, outputFile string) error {
 // EncryptStream encrypts data from an input stream and writes to an output stream using the Encryptor's public key.
 //
 // TODO: Improve this. It should be an object that can be stored (e.g., in a database or storage mechanism) for compatibility with HPA in Kubernetes.
+// It should be secure enough that even if it is exposed to the public (e.g., a human error, missconfigured related storage mechanism such as bucket), the data remains protected due to encryption.
 func (e *Encryptor) EncryptStream(input io.Reader, output io.Writer) error {
 	// Create a key ring from the public key
 	keyRing, err := e.createKeyRing()

--- a/backend/internal/middleware/authentication/crypto/gpg/encrypt.go
+++ b/backend/internal/middleware/authentication/crypto/gpg/encrypt.go
@@ -71,7 +71,8 @@ func (e *Encryptor) EncryptFile(inputFile, outputFile string) error {
 // EncryptStream encrypts data from an input stream and writes to an output stream using the Encryptor's public key.
 //
 // TODO: Improve this. It should be an object that can be stored (e.g., in a database or storage mechanism) for compatibility with HPA in Kubernetes.
-// It should be secure enough that even if it is exposed to the public (e.g., a human error, missconfigured related storage mechanism such as bucket), the data remains protected due to encryption.
+// It should be secure enough that even if it is exposed to the public (e.g., a human error, missconfigured related storage mechanism such as bucket),
+// the data remains protected due to encryption.
 func (e *Encryptor) EncryptStream(input io.Reader, output io.Writer) error {
 	// Create a key ring from the public key
 	keyRing, err := e.createKeyRing()

--- a/backend/internal/middleware/authentication/crypto/gpg/encrypt_test.go
+++ b/backend/internal/middleware/authentication/crypto/gpg/encrypt_test.go
@@ -62,7 +62,7 @@ func TestEncryptFile(t *testing.T) {
 	defer os.Remove(outputFile)
 
 	// Encrypt the backup file
-	gpg, err := gpg.NewEncryptor(testPublicKey)
+	gpg, err := gpg.NewEncryptor([]string{testPublicKey})
 	if err != nil {
 		t.Fatalf("Failed to create encryptor: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestEncryptStream(t *testing.T) {
 	// Create a buffer to simulate the output file
 	outputBuffer := &bytes.Buffer{}
 
-	gpg, err := gpg.NewEncryptor(testPublicKey)
+	gpg, err := gpg.NewEncryptor([]string{testPublicKey})
 	if err != nil {
 		t.Fatalf("Failed to create encryptor: %v", err)
 	}

--- a/backend/internal/middleware/authentication/crypto/gpg/key_ring.go
+++ b/backend/internal/middleware/authentication/crypto/gpg/key_ring.go
@@ -13,14 +13,23 @@ import (
 
 // createKeyRing creates a KeyRing from the public key.
 func (e *Encryptor) createKeyRing() (*crypto.KeyRing, error) {
-	key, err := crypto.NewKeyFromArmored(e.publicKey)
-	if err != nil {
-		return nil, fmt.Errorf("invalid public key: %w", err)
-	}
+	var keyRing *crypto.KeyRing
 
-	keyRing, err := crypto.NewKeyRing(key)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create key ring: %w", err)
+	for _, pubKey := range e.publicKey {
+		key, err := crypto.NewKeyFromArmored(pubKey)
+		if err != nil {
+			return nil, fmt.Errorf("invalid public key: %w", err)
+		}
+
+		if keyRing == nil {
+			keyRing, err = crypto.NewKeyRing(key)
+		} else {
+			err = keyRing.AddKey(key)
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("failed to add key to key ring: %w", err)
+		}
 	}
 
 	return keyRing, nil


### PR DESCRIPTION
- [+] feat(database/backup.go, mysql_redis.go): change publicKey parameter from string to slice of strings in BackupTablesWithGPG function
- [+] refactor(crypto/gpg): update NewEncryptor and createKeyRing to handle multiple public keys
- [+] test(crypto/gpg): update test cases to use slice of public keys instead of a single key