### PR TITLE
Refactor [Crypto] [GPG/OpenPGP] [Helper Function] Meta Data (Header)

### DIFF
--- a/backend/internal/middleware/authentication/crypto/gpg/encrypt.go
+++ b/backend/internal/middleware/authentication/crypto/gpg/encrypt.go
@@ -38,7 +38,7 @@ func (e *Encryptor) EncryptFile(inputFile, outputFile string) error {
 	// Create metadata (header) for the encryption
 	metadata := &crypto.PlainMessageMetadata{
 		IsBinary: true,
-		Filename: outFile.Name(),
+		Filename: inFile.Name(),
 		ModTime:  crypto.GetUnixTime(),
 	}
 


### PR DESCRIPTION
- [+] refactor(encrypt.go): use inFile.Name() instead of outFile.Name() for metadata filename