### PR TITLE
Update Benchmark [Crypto] [GPG/OpenPGP] [Helper Function] Streaming Encryption

### DIFF
--- a/backend/internal/middleware/authentication/crypto/gpg/benchmark_test.go
+++ b/backend/internal/middleware/authentication/crypto/gpg/benchmark_test.go
@@ -28,7 +28,11 @@ func BenchmarkEncryptLargeFile(b *testing.B) {
 	}
 	defer os.Remove(inputFile.Name())
 
-	// Write 1 GiB of data to the input file
+	// Write 1 GiB of data to the input file.
+	//
+	// Note: During benchmark testing, this operation uses memory allocation. However, in production, memory usage should be minimal,
+	// even for large data sizes (e.g., 250 MB+ backup sql), with memory usage around 15-16 MB.
+	// This is because data is streamed directly from the file/disk, not held in memory.
 	const size = 1 << 30 // 1 GiB
 	data := make([]byte, size)
 	_, err = inputFile.Write(data)


### PR DESCRIPTION

- [+] docs(benchmark_test.go): add note about memory usage during large file encryption