### PR TITLE
Implement [Startup Async] Disable HTTP Insecure Mechanisms

### DIFF
--- a/backend/internal/server/startup_async.go
+++ b/backend/internal/server/startup_async.go
@@ -35,7 +35,7 @@ var (
 
 	// disableHTTPInsecure determines if the server should avoid listening on port 80 for HTTP.
 	// This is controlled by the DISABLE_PORT_HTTPINSECURE environment variable.
-	// If set to "true", the server will not set up an HTTP listener on port 80 otherwise it will listening.
+	// If set to "true", the server will not set up an HTTP listener on port 80 otherwise it will listening (e.g., keep empty the env).
 	disableHTTPInsecure = os.Getenv(env.DISABLEDEFAULTPORTHTTP) == "true"
 )
 

--- a/env/env.go
+++ b/env/env.go
@@ -56,6 +56,10 @@ const (
 	// If the implementation is incorrect, this ship ⛵ BlackPearl, will be shrinking.
 	SERVERCERTTLS = "TLS_CERT_FILE"
 	SERVERKEYTLS  = "TLS_KEY_FILE"
+	// DISABLEDEFAULTPORTHTTP determines whether the application should disable listening on the default HTTP port (port 80).
+	// Set this environment variable to "true" to prevent the server from accepting insecure HTTP connections.
+	// This enhances security by ensuring that only secure connections (HTTPS/TLS) are accepted.
+	DISABLEDEFAULTPORTHTTP = "DISABLE_PORT_HTTPINSECURE"
 )
 
 // Site Middleware Configuration (Optional since it boilerplate and must rewrite a "DomainRouter" in RegisterRoutes (see backend/internal/middleware/routes.go))


### PR DESCRIPTION
- [+] feat(startup_async.go, env.go): add DISABLE_PORT_HTTPINSECURE environment variable to disable insecure HTTP connections on port 80