### PR TITLE
Fix [Database] [Constant] Typo

### DIFF
--- a/backend/internal/database/constant.go
+++ b/backend/internal/database/constant.go
@@ -63,7 +63,7 @@ const (
 	// DefaultBackupCtxTimeout is the default timeout for backup context operations, set to 30 minutes.
 	DefaultBackupCtxTimeout = 30 * time.Minute
 
-	// DefaultBackupCtxTimeout is the default timeout for ping context operations, set to 5 seconds.
+	// DefaultPingCtxTimeout is the default timeout for ping context operations, set to 5 seconds.
 	DefaultPingCtxTimeout = 5 * time.Second
 )
 


### PR DESCRIPTION
- [+] fix(constant.go): correct comment for DefaultPingCtxTimeout constant