### PR TITLE
Test [GPG/OpenPGP] Keybox visual inspection

### DIFF
--- a/backend/internal/middleware/authentication/crypto/gpg/keybox_test.go
+++ b/backend/internal/middleware/authentication/crypto/gpg/keybox_test.go
@@ -36,6 +36,16 @@ func TestKeybox_SaveAndLoad(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	// Output the JSON format for visual inspection.
+	//
+	// This format will not be corrupted and provides better readability when there are many keys.
+	// For example:
+	// [
+	// "-----BEGIN PGP PUBLIC KEY BLOCK-----\n...\n-----END PGP PUBLIC KEY BLOCK-----",
+	// "-----BEGIN PGP PUBLIC KEY BLOCK-----\n...\n-----END PGP PUBLIC KEY BLOCK-----"
+	// ]
+	t.Logf("JSON output: %s", buffer.String())
+
 	loadedKb, err := gpg.Load(&buffer)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
- [+] test(keybox_test.go): add JSON output for visual inspection in TestKeybox_SaveAndLoad test