### PR TITLE
Docs Test [Crypto] [GPG/OpenPGP] Keybox

### DIFF
--- a/backend/internal/middleware/authentication/crypto/gpg/keybox_test.go
+++ b/backend/internal/middleware/authentication/crypto/gpg/keybox_test.go
@@ -60,6 +60,9 @@ func TestKeybox_SaveAndLoad(t *testing.T) {
 	// 	  }
 	// 	]
 	// }
+	//
+	// Also the UUID can later be used as an identifier or for other purposes as needed.
+	// It is secure, and even if someone tries to guess it, it remains a random number.
 	t.Logf("JSON output: %s", buffer.String())
 
 	loadedKb, err := gpg.Load(strings.NewReader(buffer.String()))


### PR DESCRIPTION
- [+] test(keybox_test.go): add comment explaining the purpose of UUID in JSON output