### PR TITLE
Update Docs [Crypto] [GPG/OpenPGP] [Encrypt Streaming] on-the-fly

### DIFF
--- a/backend/internal/middleware/authentication/crypto/gpg/encrypt.go
+++ b/backend/internal/middleware/authentication/crypto/gpg/encrypt.go
@@ -91,6 +91,11 @@ func (e *Encryptor) EncryptFile(inputFile, outputFile string) (err error) {
 // Note: Memory allocations may vary depending on the input and output types.
 // If writing to a file (file disk not a memory again), the allocations are minimal.
 //
+// Important: When using [EncryptStream] over a network, ensure the network is stable.
+// If the network is unstable and disconnects during encryption, the process may not complete successfully.
+// Even if it seems complete, only part of the data may be processed,
+// as EncryptStream operates as a live stream (let's say on-the-fly encryption), which means the encryption process could be incomplete.
+//
 // TODO: Implement I/O DecryptStream for real streaming (Hybrid).
 // For example, read from an encrypted input (i) and write to a decrypted output (o).
 func (e *Encryptor) EncryptStream(i io.Reader, o io.Writer) error {


### PR DESCRIPTION
- [+] docs(encrypt.go): add warning about using EncryptStream over unstable networks