### PR TITLE
Update Docs [K8S Deployment] REST APIs

### DIFF
--- a/k8s-deployment/RESTAPIs.md
+++ b/k8s-deployment/RESTAPIs.md
@@ -331,7 +331,7 @@ The annotations `nginx.ingress.kubernetes.io/session-cookie-max-age`, `nginx.ing
 
 > [!TIP]
 > The [Session/Cookie](https://docs.gofiber.io/api/middleware/session) mechanism in the [`Fiber Framework`](https://gofiber.io/) 
-> is compatible with `HPA` (Horizontal Pod Autoscaling) for large-scale applications + multiple sites in one deployment, as long as you do not use the storage option that relies on [`direct memory`](https://docs.gofiber.io/storage/memory_v2.x.x/memory/).
+> is compatible with `HPA` (Horizontal Pod Autoscaling) for large-scale applications + multiple sites in single deployment, as long as you do not use the storage option that relies on [`direct memory`](https://docs.gofiber.io/storage/memory_v2.x.x/memory/).
 
 > [!WARNING]
 > While this boilerplate uses the [`Fiber Framework`](https://gofiber.io/), it is compatible with `HPA` (Horizontal Pod Autoscaling) for large-scale applications and multiple sites in a single deployment. 


### PR DESCRIPTION
- [+] docs(RESTAPIs.md): change 'one deployment' to 'single deployment' in Fiber Framework tip section