### PR TITLE
Upgrade Go Version to Latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module h0llyw00dz-template
 
-go 1.23.2
+go 1.23.3
 
 require (
 	github.com/H0llyW00dzZ/FiberValidator v0.5.2


### PR DESCRIPTION
- [+] chore(go.mod): upgrade Go version from 1.23.2 to 1.23.

Note: This should work well without any issues.