### PR TITLE
Improve Performance [Database] [Redis] [ScanAndDel Method] Base Count

### DIFF
--- a/backend/internal/database/mysql_redis.go
+++ b/backend/internal/database/mysql_redis.go
@@ -767,7 +767,9 @@ func (s *service) ScanAndDel(ctx context.Context, patterns []string) error {
 
 	var totalDeleted int
 	// Note: The count is dynamically adjusted based on performance.
-	baseCount := 100   // Initial count for retrieving keys
+	// This is sufficient, unlike Redis Insight, which can encounter blank screens (on windows hahaha) or OOM errors (on k8s hahaha) with many key-value pairs,
+	// such as millions/billions.
+	baseCount := 1     // Initial count for retrieving keys
 	maxCount := 100000 // Maximum limit for the count; if insufficient, it can be increased to 1 million
 
 	for _, pattern := range patterns {


### PR DESCRIPTION
- [+] fix(mysql_redis.go): reduce baseCount for retrieving keys from 100 to 1