### PR TITLE
Test [pkg] [Helper Function] [CIDR] ValidateAndParseIPs

### DIFF
--- a/backend/pkg/network/cidr/validate_test.go
+++ b/backend/pkg/network/cidr/validate_test.go
@@ -49,6 +49,27 @@ func TestValidateAndParseIPs(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name:        "Invalid CIDR",
+			envVarValue: "999.999.999.999/999",
+			defaultIPS:  "0.0.0.0/0",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "Multiple invalid entries",
+			envVarValue: "999.999.999.999, 999.999.999.999/999",
+			defaultIPS:  "0.0.0.0/0",
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "Multiple invalid entries, expected one valid",
+			envVarValue: "999.999.999.999, 999.999.999.999/999, 192.168.1.1",
+			defaultIPS:  "0.0.0.0/0",
+			expected:    []string{"192.168.1.1"},
+			expectError: true,
+		},
+		{
 			name:        "Default value used",
 			envVarValue: "0.0.0.0/0",
 			defaultIPS:  "0.0.0.0/0",


### PR DESCRIPTION
- [+] test(validate_test.go): add test cases for invalid CIDR inputs
- [+] test(validate_test.go): add test case for multiple invalid entries
- [+] test(validate_test.go): add test case for multiple invalid entries with one expected valid entry
- [+] test(validate_test.go): add test case for default value used