### PR TITLE
Docs [K8S Deployment] [REST APIs] [Important] Update Documentation

### DIFF
--- a/k8s-deployment/RESTAPIs.md
+++ b/k8s-deployment/RESTAPIs.md
@@ -589,6 +589,9 @@ To set up an `HTTPS/TLS certificate` without using [cert-manager.io](https://cer
 > It's also worth noting that if you issue an HTTPS/TLS certificate from a trusted public certificate service, they may provide the certificate without the full chain, consider it bad practice for them 👎. 
 > Be aware that some trusted public certificate services might not handle PKI operations optimally, regardless of their trust level.
 
+> [!WARNING]
+> Avoid manually chaining `HTTPS/TLS certificates` using methods like hardcoding with `Bash` or using the `cat` command. It's best to use tools written in Go, such as the [cert chain resolver](https://github.com/zakjan/cert-chain-resolver.git). Manually chaining certificates can lead to `invalid/miss configurations`.
+
 ### Enhance Ingress NGINX for Large Scalability (e.g., Handling Many Nodes)
 
 To enhance Ingress NGINX for large scalability, especially when managing this REST APIs with HPA, follow these guidelines. If you have the capacity of a `single rack server` (`e.g., single/multi-tenant`), deploy Ingress NGINX on a node that isn't `heavily loaded—ideally`, a node running only Kubernetes components.


### PR DESCRIPTION
- [+] docs(RESTAPIs.md): add warning about manually chaining HTTPS/TLS certificates
- [+] docs(RESTAPIs.md): enhance Ingress NGINX for large scalability