### PR TITLE
TODO: [Backend] [Router Logic] [Router Domain] Support multiple wwwDot

### DIFF
--- a/backend/internal/middleware/router/domain/config.go
+++ b/backend/internal/middleware/router/domain/config.go
@@ -23,6 +23,8 @@ type (
 		// Note: This is optional and depends on your HTTPS/TLS configuration.
 		// If your certificate is a wildcard or explicitly includes "www.", this is suitable,
 		// even when using a proxy or Kubernetes Ingress.
+		//
+		// TODO: Use "[]string" to support multiple websites for better scalability.
 		MainDomain string
 	}
 )


### PR DESCRIPTION
- [+] docs(config.go): add comment about using []string for multiple websites support in MainDomain