### PR TITLE
Remove Unused Fiber Prometheus Configuration Cache Key

### DIFF
--- a/backend/internal/middleware/helper.go
+++ b/backend/internal/middleware/helper.go
@@ -1061,13 +1061,6 @@ func WithPrometheusMetricsNext(next func(c *fiber.Ctx) bool) func(*monitor.Prome
 	}
 }
 
-// WithPrometheusCacheKey is an option function for NewPrometheus that sets the cache key.
-func WithPrometheusCacheKey(cacheKey string) func(*monitor.PrometheusConfig) {
-	return func(config *monitor.PrometheusConfig) {
-		config.CacheKey = cacheKey
-	}
-}
-
 // WithRestimeHeaderName is an option function for ResponseTime that sets the header name.
 func WithRestimeHeaderName(headerName string) func(*restime.Config) {
 	return func(config *restime.Config) {

--- a/backend/internal/middleware/monitor/prometheus.go
+++ b/backend/internal/middleware/monitor/prometheus.go
@@ -41,12 +41,6 @@ type PrometheusConfig struct {
 	// The middleware will be skipped if this function returns true.
 	// Optional. Default is nil.
 	Next func(c *fiber.Ctx) bool
-
-	// CacheKey is the cache key used for caching the Prometheus metrics.
-	// Optional. Default is an empty string.
-	//
-	// TODO: Enhance the Prometheus Portable middleware to support multiple headers for logging instead of a single header like "X-Cache".
-	CacheKey string
 }
 
 // DefaultPrometheusConfig represents the default configuration options for the Prometheus middleware.
@@ -83,10 +77,6 @@ func NewPrometheus(config ...PrometheusConfig) fiber.Handler {
 
 	if len(cfg.SkipPaths) > 0 {
 		prometheus.SetSkipPaths(cfg.SkipPaths)
-	}
-
-	if cfg.CacheKey != "" {
-		prometheus.CustomCacheKey(cfg.CacheKey)
 	}
 
 	return func(c *fiber.Ctx) error {

--- a/backend/internal/middleware/restapis_routes.go
+++ b/backend/internal/middleware/restapis_routes.go
@@ -109,7 +109,6 @@ func registerRESTAPIsRoutes(api fiber.Router, db database.Service) {
 			// Ideally, the data should be stored in storage (e.g., disk) instead of memory. If this doesn't work, then use Next.
 			"/favicon.ico",
 		}),
-		WithPrometheusCacheKey("X-Go-Frontend"),
 		WithPrometheusMetricsPaths("/v1/server/metrics"),
 	)
 


### PR DESCRIPTION
- [+] refactor(middleware): remove WithPrometheusCacheKey function and related cache key references from PrometheusConfig