### PR TITLE
Update [Docs] [K8S Deployment] [Component] AWS Cluster Autoscaler

### DIFF
--- a/k8s-deployment/component/ca-autoscaler/aws/README.md
+++ b/k8s-deployment/component/ca-autoscaler/aws/README.md
@@ -20,6 +20,21 @@ Before deploying the Cluster Autoscaler, ensure that you have the following prer
 
    Update the `helm-values.yaml` file with your specific cluster configuration, such as the cluster name, AWS region, and IAM role ARN.
 
+   > [!IMPORTANT]
+   > The Cluster Autoscaler requires `awsAccessKeyID` and `awsSecretAccessKey` to function properly. You can create a user and attach the `ca-policy.json` to that user related to these credentials. Without these credentials, the Cluster Autoscaler won't work, and installing it manually without Helm will also result in misconfiguration issues related to the region. This is due to the lack of proper configuration.
+
+   Make sure to set the `awsAccessKeyID` and `awsSecretAccessKey` values in the `helm-values.yaml` file:
+
+   ```yaml
+   awsAccessKeyID: "*"
+   awsSecretAccessKey: "*"
+   ```
+
+   Replace `"*"` with your actual AWS access key ID and secret access key.
+
+   > [!NOTE]
+   > The credentials related to `awsAccessKeyID` and `awsSecretAccessKey` are also safe because they will be automatically created as Kubernetes secrets when installing via Helm.
+
 ## Deployment
 
 1. Add the Cluster Autoscaler Helm repository:

--- a/k8s-deployment/component/ca-autoscaler/aws/helm-values.yaml
+++ b/k8s-deployment/component/ca-autoscaler/aws/helm-values.yaml
@@ -2,6 +2,9 @@ autoDiscovery:
   clusterName: <your_clustername>  # Replace with your actual cluster name
 
 awsRegion: <your_region>  # Replace with your AWS region
+# This requires awsAccessKeyID & awsSecretAccessKey. You can create a user and attach the ca-policy.json to that user related to these credentials.
+# It won't work without these credentials, and installing manually without Helm will also result in misconfiguration issues related to the region.
+# This is due to the lack of proper configuration.
 awsAccessKeyID: "*"
 awsSecretAccessKey: "*"
 


### PR DESCRIPTION
- [+] docs(README.md): add important notes about awsAccessKeyID and awsSecretAccessKey requirements for Cluster Autoscaler
- [+] docs(helm-values.yaml): clarify the need for awsAccessKeyID and awsSecretAccessKey in configuration