### PR TITLE
Revert "Improve [K8S Deployment] [Component] [StorageClasses] [AWS EBS StorageClass Configurations] gp2, gp3, io1, io2 (#1642)"

### DIFF
--- a/k8s-deployment/component/storageclasses/aws/ebs/gp.yaml
+++ b/k8s-deployment/component/storageclasses/aws/ebs/gp.yaml
@@ -2,7 +2,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: gp2-encrypted-retain
-  description: "GP2 storage class with encryption enabled and retain reclaim policy. Provides a baseline performance of 3 IOPS per GiB, with the ability to burst to 3,000 IOPS for extended periods of time. Suitable for general-purpose workloads."
 provisioner: ebs.csi.aws.com
 parameters:
   type: gp2
@@ -15,7 +14,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: gp2-retain
-  description: "GP2 storage class with encryption disabled and retain reclaim policy. Provides a baseline performance of 3 IOPS per GiB, with the ability to burst to 3,000 IOPS for extended periods of time. Suitable for general-purpose workloads."
 provisioner: ebs.csi.aws.com
 parameters:
   type: gp2
@@ -28,7 +26,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: gp2-encrypted
-  description: "GP2 storage class with encryption enabled and delete reclaim policy. Provides a baseline performance of 3 IOPS per GiB, with the ability to burst to 3,000 IOPS for extended periods of time. Suitable for general-purpose workloads."
 provisioner: ebs.csi.aws.com
 parameters:
   type: gp2
@@ -41,7 +38,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: gp2
-  description: "GP2 storage class with encryption disabled and delete reclaim policy. Provides a baseline performance of 3 IOPS per GiB, with the ability to burst to 3,000 IOPS for extended periods of time. Suitable for general-purpose workloads."
 provisioner: ebs.csi.aws.com
 parameters:
   type: gp2
@@ -54,7 +50,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: gp3-encrypted-retain
-  description: "GP3 storage class with encryption enabled and retain reclaim policy. Provides a baseline performance of 3,000 IOPS and 125 MiB/s throughput per volume, with the ability to provision up to 16,000 IOPS and 1,000 MiB/s throughput. Suitable for high-performance workloads."
 provisioner: ebs.csi.aws.com
 parameters:
   type: gp3
@@ -67,7 +62,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: gp3-retain
-  description: "GP3 storage class with encryption disabled and retain reclaim policy. Provides a baseline performance of 3,000 IOPS and 125 MiB/s throughput per volume, with the ability to provision up to 16,000 IOPS and 1,000 MiB/s throughput. Suitable for high-performance workloads."
 provisioner: ebs.csi.aws.com
 parameters:
   type: gp3
@@ -80,7 +74,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: gp3-encrypted
-  description: "GP3 storage class with encryption enabled and delete reclaim policy. Provides a baseline performance of 3,000 IOPS and 125 MiB/s throughput per volume, with the ability to provision up to 16,000 IOPS and 1,000 MiB/s throughput. Suitable for high-performance workloads."
 provisioner: ebs.csi.aws.com
 parameters:
   type: gp3
@@ -93,7 +86,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: gp3
-  description: "GP3 storage class with encryption disabled and delete reclaim policy. Provides a baseline performance of 3,000 IOPS and 125 MiB/s throughput per volume, with the ability to provision up to 16,000 IOPS and 1,000 MiB/s throughput. Suitable for high-performance workloads."
 provisioner: ebs.csi.aws.com
 parameters:
   type: gp3

--- a/k8s-deployment/component/storageclasses/aws/ebs/io.yaml
+++ b/k8s-deployment/component/storageclasses/aws/ebs/io.yaml
@@ -2,7 +2,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: io1-encrypted-retain
-  description: "IO1 storage class with encryption enabled and retain reclaim policy. Provides high-performance storage with consistent IOPS. Supports up to 50 IOPS per GiB, with a maximum of 64,000 IOPS per volume. Suitable for I/O-intensive workloads that require low latency and high throughput."
 provisioner: ebs.csi.aws.com
 parameters:
   type: io1
@@ -16,7 +15,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: io1-retain
-  description: "IO1 storage class with encryption disabled and retain reclaim policy. Provides high-performance storage with consistent IOPS. Supports up to 50 IOPS per GiB, with a maximum of 64,000 IOPS per volume. Suitable for I/O-intensive workloads that require low latency and high throughput."
 provisioner: ebs.csi.aws.com
 parameters:
   type: io1
@@ -30,7 +28,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: io1-encrypted
-  description: "IO1 storage class with encryption enabled and delete reclaim policy. Provides high-performance storage with consistent IOPS. Supports up to 50 IOPS per GiB, with a maximum of 64,000 IOPS per volume. Suitable for I/O-intensive workloads that require low latency and high throughput."
 provisioner: ebs.csi.aws.com
 parameters:
   type: io1
@@ -44,7 +41,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: io1
-  description: "IO1 storage class with encryption disabled and delete reclaim policy. Provides high-performance storage with consistent IOPS. Supports up to 50 IOPS per GiB, with a maximum of 64,000 IOPS per volume. Suitable for I/O-intensive workloads that require low latency and high throughput."
 provisioner: ebs.csi.aws.com
 parameters:
   type: io1
@@ -58,7 +54,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: io2-encrypted-retain
-  description: "IO2 storage class with encryption enabled and retain reclaim policy. Provides the highest performance storage with consistent IOPS and low latency. Supports up to 500 IOPS per GiB, with a maximum of 64,000 IOPS per volume. Suitable for mission-critical, I/O-intensive workloads that require superior performance and durability."
 provisioner: ebs.csi.aws.com
 parameters:
   type: io2
@@ -72,7 +67,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: io2-retain
-  description: "IO2 storage class with encryption disabled and retain reclaim policy. Provides the highest performance storage with consistent IOPS and low latency. Supports up to 500 IOPS per GiB, with a maximum of 64,000 IOPS per volume. Suitable for mission-critical, I/O-intensive workloads that require superior performance and durability."
 provisioner: ebs.csi.aws.com
 parameters:
   type: io2
@@ -86,7 +80,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: io2-encrypted
-  description: "IO2 storage class with encryption enabled and delete reclaim policy. Provides the highest performance storage with consistent IOPS and low latency. Supports up to 500 IOPS per GiB, with a maximum of 64,000 IOPS per volume. Suitable for mission-critical, I/O-intensive workloads that require superior performance and durability."
 provisioner: ebs.csi.aws.com
 parameters:
   type: io2
@@ -100,7 +93,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: io2
-  description: "IO2 storage class with encryption disabled and delete reclaim policy. Provides the highest performance storage with consistent IOPS and low latency. Supports up to 500 IOPS per GiB, with a maximum of 64,000 IOPS per volume. Suitable for mission-critical, I/O-intensive workloads that require superior performance and durability."
 provisioner: ebs.csi.aws.com
 parameters:
   type: io2


### PR DESCRIPTION
This reverts commit baace90de4f0e583fa1c1ee23fce4f88de0a6b33.

Reason: It doesn't support the description, even when included as a parameter.