### PR TITLE
Update Docs [Backend] [Middleware] [Authentication] OAuth2 Web Version

### DIFF
--- a/backend/internal/middleware/authentication/oauth2/new.go
+++ b/backend/internal/middleware/authentication/oauth2/new.go
@@ -55,7 +55,7 @@ type Manager struct {
 //
 //	// Create the OAuth2 configuration
 //	cfg := oauth2.Config{
-//		Provider:      "Google",
+//		Provider:      oauth2.ProviderGoogle,
 //		ClientID:      "your-client-id",
 //		ClientSecret:  "your-client-secret",
 //		RedirectURL:   "your-redirect-url",


### PR DESCRIPTION
- [+] fix(oauth2/new.go): update OAuth2 provider string to use oauth2.ProviderGoogle constant