### PR TITLE
Improve [Backend] [Pkg] [Helper Function] [Convert] [HTMLToPlainText] Remove Element Style CSS

### DIFF
--- a/backend/pkg/convert/html_to_plaintext.go
+++ b/backend/pkg/convert/html_to_plaintext.go
@@ -17,7 +17,7 @@ import (
 // It parses the HTML and extracts text nodes, concatenating them into a single string.
 // If parsing fails, it returns the original HTML content as a fallback.
 //
-// Note: This function does not fully handle elements like "<style>" or other non-text content.
+// Note: This function does not fully handle elements like "<script>" or other non-text content.
 //
 // TODO: Improving this will require additional filtering, possibly using regex.
 func HTMLToPlainText(htmlContent string) string {
@@ -70,6 +70,9 @@ func extractText(n *html.Node, textContent *strings.Builder, inList bool) {
 	if n.Type == html.TextNode {
 		textContent.WriteString(n.Data)
 	} else if n.Type == html.ElementNode {
+		if n.Data == "style" {
+			return // Skip <style> tags entirely
+		}
 		if n.Data == "a" {
 			handleAnchorTag(n, textContent)
 			return // Skip further processing for child nodes of <a>

--- a/backend/pkg/convert/html_to_plaintext_test.go
+++ b/backend/pkg/convert/html_to_plaintext_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func TestHTMLToPlainText(t *testing.T) {
-	// Note: This test might depend on the OS. Linux/Unix uses "\n", while Windows uses "\r\n" due to MS-DOS conventions.
-	// When testing on Windows, "\r" might be required.
+	// Determine the newline character based on the operating system.
 	crlf := "\n"
 	if runtime.GOOS == "windows" {
 		crlf = "\r\n"
@@ -73,6 +72,22 @@ func TestHTMLToPlainText(t *testing.T) {
 			name:     "Multiple Paragraphs",
 			input:    "<p>Hello HTML Frontend, from Go.</p><p>Hello HTML Frontend, from Go.</p>",
 			expected: crlf + crlf + "Hello HTML Frontend, from Go." + crlf + crlf + crlf + crlf + "Hello HTML Frontend, from Go." + crlf + crlf,
+		},
+		{
+			name: "Complex with Style",
+			input: `<style>
+						body { font-family: Arial; }
+					</style>
+					<p>Hello HTML Frontend, from Go.</p>`,
+			expected: crlf + "\t\t\t\t\t" + crlf + crlf + "Hello HTML Frontend, from Go." + crlf + crlf,
+		},
+		{
+			name: "Style with Class",
+			input: `<style class="example">
+						.example { color: red; }
+					</style>
+					<p>Hello HTML Frontend, from Go.</p>`,
+			expected: crlf + "\t\t\t\t\t" + crlf + crlf + "Hello HTML Frontend, from Go." + crlf + crlf,
 		},
 	}
 


### PR DESCRIPTION
- [+] fix(html_to_plaintext.go): update comment to reflect handling of <script> tags instead of <style> tags
- [+] feat(html_to_plaintext.go): skip <style> tags entirely during text extraction
- [+] test(html_to_plaintext_test.go): add tests for handling <style> tags in HTML content