### PR TITLE
TODO [Backend] [Pkg] [Helper Function] [Convert] [HTMLToPlainText] Automatically handle the size of the image

### DIFF
--- a/backend/pkg/convert/html_to_plaintext.go
+++ b/backend/pkg/convert/html_to_plaintext.go
@@ -157,6 +157,8 @@ func HTMLToPlainTextStreams(i io.Reader, o io.Writer) error {
 }
 
 // handleImageTag processes <img> tags.
+//
+// TODO: Automatically handle the size of the image as well.
 func handleImageTag(n *html.Node, textContent *strings.Builder) {
 	src := ""
 	alt := ""


### PR DESCRIPTION
- [+] docs(html_to_plaintext.go): add TODO comment to handle image size in handleImageTag function