### PR TITLE
Refactor [Backend] [Pkg] [Helper Function] [Convert] [HTMLToPlainText] Buffer Pool Management

### DIFF
--- a/backend/pkg/convert/helper.go
+++ b/backend/pkg/convert/helper.go
@@ -101,20 +101,7 @@ var (
 	builderPool = sync.Pool{
 		New: func() any { return new(strings.Builder) },
 	}
-
-	// bufferPool provides reusable byte slices.
-	// Each buffer is 32KB, suitable for handling moderate-sized data chunks.
-	bufferPool = sync.Pool{
-		// Not good if the buffer size is too large.
-		New: func() any { return &buffer{buf: make([]byte, 32*1024)} }, // 32KB buffer
-	}
 )
-
-// buffer wraps a byte slice and provides a reset method.
-type buffer struct{ buf []byte }
-
-// reset clears the buffer for reuse.
-func (b *buffer) reset() { b.buf = b.buf[:0] }
 
 // getBuilder retrieves a [*strings.Builder] from the pool.
 // If none are available, it creates a new one.
@@ -125,15 +112,6 @@ func getBuilder() *strings.Builder { return builderPool.Get().(*strings.Builder)
 func putBuilder(b *strings.Builder) {
 	b.Reset()
 	builderPool.Put(b)
-}
-
-// getBuffer retrieves a buffer from the pool.
-func getBuffer() *buffer { return bufferPool.Get().(*buffer) }
-
-// putBuffer returns a buffer to the pool.
-func putBuffer(b *buffer) {
-	b.reset()
-	bufferPool.Put(b)
 }
 
 // getNewline returns the appropriate newline characters based on the operating system.

--- a/backend/pkg/convert/html_to_plaintext.go
+++ b/backend/pkg/convert/html_to_plaintext.go
@@ -258,9 +258,6 @@ func processImage(n *html.Node, state *textState) {
 //
 // TODO: Improving this will require additional filtering, possibly using regex.
 func HTMLToPlainTextStreams(i io.Reader, o io.Writer) error {
-	buf := getBuffer()
-	defer putBuffer(buf)
-
 	builder := getBuilder()
 	defer putBuilder(builder)
 


### PR DESCRIPTION
- [+] refactor(helper.go): remove unused bufferPool and related methods
- [+] refactor(html_to_plaintext.go): eliminate buffer usage in HTMLToPlainTextStreams function

Note: It's better to use a string builder from the pool. Previously, another method was attempted, but using a string builder is more efficient.