### PR TITLE
Update Docs [K8S Deployment] Gitea Docker-in-Docker (DinD) Runner

### DIFF
--- a/k8s-deployment/Gitea-Runner.md
+++ b/k8s-deployment/Gitea-Runner.md
@@ -17,12 +17,16 @@ The Gitea DinD Runner allows you to execute CI/CD jobs within a Kubernetes clust
 > For Example:
 > ![Screenshot from 2025-03-18 23-53-13](https://github.com/user-attachments/assets/7e00ddfc-3716-4b24-9081-cbe308122c2d)
 >
+> ![Screenshot from 2025-03-20 05-12-57.png](https://github.com/user-attachments/assets/b317a458-c398-47fd-b79c-e12d08d22c96)
+> 
 > ![Screenshot from 2025-03-18 23-53-57](https://github.com/user-attachments/assets/19783ce0-983d-4e04-9be2-f67407ac2eb8)
 >
 > Note that Gitea itself (self-hosted) is also running in a Kubernetes container.
 >
 > The performance is also different when building images with QEMU (e.g., it won't get stuck forever when building multi-arch images, unlike building outside of the cluster, which can cause the process to get stuck forever or become very slow).
 > This is especially true when your cluster has built-in custom resources such as node pools like EKS Auto Mode. It basically becomes a layer on top of Kubernetes, because you can specify node specs through node pools, and your infrastructure always runs smoothly while sailing 🛳️ the Kubernetes seas ☸.
+>
+> The Docker context also uses TCP with TLS enabled, rather than the default socket (e.g., `unix:///var/run/docker.sock`), to ensure compatibility with DinD (Docker-in-Docker) managed by Kubernetes.
 
 ## Prerequisites
 


### PR DESCRIPTION
- [+] docs(Gitea-Runner.md): add additional screenshots and clarify Docker context usage with TCP and TLS for DinD compatibility