### PR TITLE
Improve [Backend] [Pkg] [Helper Function] [Convert] HTMLToPlainText

### DIFF
--- a/backend/pkg/convert/html_to_plaintext.go
+++ b/backend/pkg/convert/html_to_plaintext.go
@@ -142,11 +142,16 @@ func handleElementStart(n *html.Node, state *textState) {
 		state.headerParsed = false
 		state.builder.WriteString(state.nl)
 		state.needSpace = false
+		// Note: The tr, td, and th elements should now be correct and will only display formatting if they are inside a table.
 	case "tr":
-		state.builder.WriteString("| ")
+		if state.inTable {
+			state.builder.WriteString("| ")
+		}
 		state.needSpace = false
 	case "td", "th":
-		state.builder.WriteString(" ")
+		if state.inTable {
+			state.builder.WriteString(" ")
+		}
 		state.needSpace = false
 	}
 }
@@ -175,16 +180,21 @@ func handleElementEnd(n *html.Node, state *textState) {
 		state.inTable = false
 		state.builder.WriteString(state.nl + state.nl)
 		state.needSpace = false
+		// Note: The tr, td, and th elements should now be correct and will only display formatting if they are inside a table.
 	case "tr":
-		state.builder.WriteString(state.nl)
-		if state.inTable && !state.headerParsed {
-			state.headerParsed = true
-			addHeaderSeparator(state)
+		if state.inTable {
+			state.builder.WriteString(state.nl)
+			if !state.headerParsed {
+				state.headerParsed = true
+				addHeaderSeparator(state)
+			}
 		}
 		state.needSpace = false
 	case "td", "th":
-		state.builder.WriteString(" |")
-		state.needSpace = true
+		if state.inTable {
+			state.builder.WriteString(" |")
+			state.needSpace = true
+		}
 	}
 }
 

--- a/backend/pkg/convert/html_to_plaintext_test.go
+++ b/backend/pkg/convert/html_to_plaintext_test.go
@@ -187,6 +187,21 @@ func TestHTMLToPlainText(t *testing.T) {
 					<p>Visible content.</p>`,
 			expected: crlf + crlf + "Visible content." + crlf + crlf,
 		},
+		{
+			name:     "TR without Table",
+			input:    "<tr><td>Data</td></tr>",
+			expected: "Data",
+		},
+		{
+			name:     "TD without Table",
+			input:    "<td>Data</td>",
+			expected: "Data",
+		},
+		{
+			name:     "TH without Table",
+			input:    "<th>Header</th>",
+			expected: "Header",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
- [+] fix(html_to_plaintext): update handling of table elements to prevent formatting outside tables
- [+] test(html_to_plaintext_test): add tests for tr, td, and th elements without a table