### PR TITLE
Update Docs [Backend] [Helper Function] [Crypto/Rand] [SyncMap" & "SyncMapValue] Error Handling

### DIFF
--- a/backend/internal/middleware/authentication/crypto/rand/sync_map.go
+++ b/backend/internal/middleware/authentication/crypto/rand/sync_map.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	// ErrSyncMapIsEmpty is returned by the SyncMap and SyncMapValue functions
-	// when the provided sync.Map is empty. This error indicates that there are
+	// when the provided [sync.Map] is empty. This error indicates that there are
 	// no elements to choose from.
 	ErrSyncMapIsEmpty = errors.New("crypto/rand: sync.Map is empty")
 )


### PR DESCRIPTION
- [+] fix(sync_map.go): correct comment to use [sync.Map] formatting in error message